### PR TITLE
추천 상품 캐시, OAuth2, API 구현 등

### DIFF
--- a/mall/build.gradle
+++ b/mall/build.gradle
@@ -50,6 +50,8 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-core'
 	implementation 'io.micrometer:micrometer-registry-prometheus'
+
+	implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
 }
 
 tasks.named('test') {

--- a/mall/src/main/java/yeolJyeongKong/mall/config/PrincipalDetails.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/config/PrincipalDetails.java
@@ -4,18 +4,27 @@ import lombok.Data;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import yeolJyeongKong.mall.config.auth.Oauth2UserInfo;
 import yeolJyeongKong.mall.domain.entity.User;
 
 import java.util.Collection;
+import java.util.Map;
 import java.util.stream.Collectors;
 
 @Data
-public class PrincipalDetails implements UserDetails {
+public class PrincipalDetails implements UserDetails, OAuth2User {
 
     private User user;
+    private Oauth2UserInfo oAuth2UserInfo;
 
     public PrincipalDetails(User user) {
         this.user = user;
+    }
+
+    public PrincipalDetails(User user, Oauth2UserInfo oAuth2UserInfo) {
+        this.user = user;
+        this.oAuth2UserInfo = oAuth2UserInfo;
     }
 
     @Override
@@ -26,6 +35,11 @@ public class PrincipalDetails implements UserDetails {
     }
 
     @Override
+    public Map<String, Object> getAttributes() {
+        return oAuth2UserInfo.getAttributes();
+    }
+
+    @Override
     public String getPassword() {
         return user.getPassword();
     }
@@ -33,6 +47,11 @@ public class PrincipalDetails implements UserDetails {
     @Override
     public String getUsername() {
         return user.getEmail();
+    }
+
+    @Override
+    public String getName() {
+        return oAuth2UserInfo.getProviderId();
     }
 
     @Override

--- a/mall/src/main/java/yeolJyeongKong/mall/config/PrincipalOauth2UserService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/config/PrincipalOauth2UserService.java
@@ -1,0 +1,55 @@
+package yeolJyeongKong.mall.config;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+import yeolJyeongKong.mall.config.auth.GoogleUserInfo;
+import yeolJyeongKong.mall.config.auth.KakaoUserInfo;
+import yeolJyeongKong.mall.config.auth.Oauth2UserInfo;
+import yeolJyeongKong.mall.domain.entity.User;
+import yeolJyeongKong.mall.repository.UserRepository;
+
+import java.util.Optional;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class PrincipalOauth2UserService extends DefaultOAuth2UserService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = super.loadUser(userRequest);
+
+        Oauth2UserInfo oAuth2UserInfo = null;
+        String provider = userRequest.getClientRegistration().getRegistrationId();
+
+        if (provider.equals("google")) {
+            oAuth2UserInfo = new GoogleUserInfo(oAuth2User.getAttributes());
+        } else if (provider.equals("kakao")) {
+            oAuth2UserInfo = new KakaoUserInfo(oAuth2User.getAttributes());
+        }
+
+        String providerId = oAuth2UserInfo.getProviderId();
+        String loginId = provider + "_" + providerId;
+        String email = oAuth2UserInfo.getEmail();
+
+        Optional<User> optionalUser = userRepository.findByProviderLoginId(loginId);
+        User user;
+
+        if (optionalUser.isEmpty()) {
+            user = new User(email, provider, providerId);
+            userRepository.save(user);
+        } else {
+            user = optionalUser.get();
+        }
+
+        return new PrincipalDetails(user, oAuth2UserInfo);
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/config/SecurityConfig.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/config/SecurityConfig.java
@@ -18,6 +18,8 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 import yeolJyeongKong.mall.config.jwt.JwtAuthenticationFilter;
 import yeolJyeongKong.mall.config.jwt.JwtTokenProvider;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @Slf4j
 @Configuration
 @EnableWebSecurity
@@ -42,6 +44,7 @@ public class SecurityConfig {
                                 .anyRequest().authenticated()
                 )
                 .formLogin(AbstractHttpConfigurer::disable)
+                .oauth2Login(withDefaults())
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
         return http.build();
     }

--- a/mall/src/main/java/yeolJyeongKong/mall/config/auth/GoogleUserInfo.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/config/auth/GoogleUserInfo.java
@@ -1,0 +1,36 @@
+package yeolJyeongKong.mall.config.auth;
+
+import java.util.Map;
+
+public class GoogleUserInfo implements Oauth2UserInfo {
+    private Map<String, Object> attributes;
+
+    public GoogleUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("sub").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "google";
+    }
+
+    @Override
+    public String getEmail() {
+        return attributes.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get("name").toString();
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/config/auth/KakaoUserInfo.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/config/auth/KakaoUserInfo.java
@@ -1,0 +1,40 @@
+package yeolJyeongKong.mall.config.auth;
+
+import java.util.Map;
+
+public class KakaoUserInfo implements Oauth2UserInfo {
+    private Map<String, Object> attributes;
+    private Map<String, Object> attributesAccount;
+    private Map<String, Object> attributesProfile;
+
+    public KakaoUserInfo(Map<String, Object> attributes) {
+        this.attributes = attributes;
+        this.attributesAccount = (Map<String, Object>) attributes.get("kakao_account");
+        this.attributesProfile = (Map<String, Object>) attributesAccount.get("profile");
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public String getProviderId() {
+        return attributes.get("id").toString();
+    }
+
+    @Override
+    public String getProvider() {
+        return "Kakao";
+    }
+
+    @Override
+    public String getEmail() {
+        return attributesAccount.get("email").toString();
+    }
+
+    @Override
+    public String getName() {
+        return attributesProfile.get("nickname").toString();
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/config/auth/Oauth2UserInfo.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/config/auth/Oauth2UserInfo.java
@@ -1,0 +1,11 @@
+package yeolJyeongKong.mall.config.auth;
+
+import java.util.Map;
+
+public interface Oauth2UserInfo {
+    public Map<String, Object> getAttributes();
+    String getProviderId();
+    String getProvider();
+    String getEmail();
+    String getName();
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/CategoryController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/CategoryController.java
@@ -1,0 +1,30 @@
+package yeolJyeongKong.mall.controller;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import yeolJyeongKong.mall.service.CategoryService;
+
+@Tag(name = "카테고리", description = "카테고리 서비스 관련 API")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @Operation(summary = "카테고리 등록 메소드")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"카테고리 등록 완료\"")))
+    @PostMapping("/category/add/{categoryName}")
+    public ResponseEntity<?> save(@PathVariable("categoryName") String categoryName) {
+        categoryService.save(categoryName);
+        return new ResponseEntity<>("카테고리 등록 완료", HttpStatus.OK);
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/MallController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/MallController.java
@@ -3,6 +3,7 @@ package yeolJyeongKong.mall.controller;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
 import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -12,12 +13,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import yeolJyeongKong.mall.config.PrincipalDetails;
 import yeolJyeongKong.mall.domain.dto.MallDto;
 import yeolJyeongKong.mall.domain.dto.MallPreviewDto;
 import yeolJyeongKong.mall.service.FavoriteService;
+import yeolJyeongKong.mall.service.MallService;
 import yeolJyeongKong.mall.service.RankService;
 
 import java.util.List;
@@ -28,8 +31,17 @@ import java.util.List;
 @RequestMapping("/api")
 public class MallController {
 
+    private final MallService mallService;
     private final RankService rankService;
     private final FavoriteService favoriteService;
+
+    @Operation(summary = "쇼핑몰 등록 메소드")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"쇼핑몰 등록 완료\"")))
+    @GetMapping("/malls/add")
+    public ResponseEntity<?> save(@ModelAttribute MallDto mallDto) {
+        mallService.save(mallDto);
+        return new ResponseEntity<>("쇼핑몰 등록 완료", HttpStatus.OK);
+    }
 
     @Operation(summary = "쇼핑몰 랭킹 조회 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = MallDto.class))))

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -102,6 +102,24 @@ public class UserController {
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 
+    @Operation(summary = "유저 즐겨찾기 상품 등록 메소드")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"유저 즐겨찾기 상품 등록 완료\"")))
+    @PostMapping("/user/favorite_goods/{productId}")
+    public ResponseEntity<?> saveFavoriteProduct(@PathVariable("productId") Long productId,
+                                                 @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        userService.saveFavoriteProduct(principalDetails.getUser().getId(), productId);
+        return new ResponseEntity<>("유저 즐겨찾기 상품 등록 완료", HttpStatus.OK);
+    }
+
+    @Operation(summary = "유저 즐겨찾기 상품 삭제 메소드")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"유저 즐겨찾기 상품 삭제 완료\"")))
+    @DeleteMapping("/user/favorite_goods/{productId}")
+    public ResponseEntity<?> deleteFavoriteProduct(@PathVariable("productId") Long productId,
+                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        userService.deleteFavoriteProduct(principalDetails.getUser().getId(), productId);
+        return new ResponseEntity<>("유저 즐겨찾기 상품 삭제 완료", HttpStatus.OK);
+    }
+
     @Operation(summary = "유저 최근 본 상품 조회 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ProductPreviewDto.class))))
     @GetMapping("/user/recent")

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -8,6 +8,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
@@ -118,7 +119,8 @@ public class UserController {
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 
-    private List<Long> findRecommendedProductIds(Long userId) {
+    @Cacheable(value = "recommendation", key = "#userId")
+    public List<Long> findRecommendedProductIds(Long userId) {
         List<Long> productIds = new ArrayList<>();
         List<Product> recommendedProducts = productService.productWithRecentRecommendation(userId);
 
@@ -169,7 +171,8 @@ public class UserController {
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 
-    private List<Long> findRecommendedProductIdsOnPick(Long userId) {
+    @Cacheable(value = "recommendationOnPick", key = "#userId")
+    public List<Long> findRecommendedProductIdsOnPick(Long userId) {
         List<Long> productIds = new ArrayList<>();
         List<Product> recommendedProducts = productService.productWithUserRecommendation(userId);
 

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -23,6 +23,7 @@ import yeolJyeongKong.mall.domain.entity.RecentRecommendation;
 import yeolJyeongKong.mall.domain.entity.UserRecommendation;
 import yeolJyeongKong.mall.service.FavoriteService;
 import yeolJyeongKong.mall.service.ProductService;
+import yeolJyeongKong.mall.service.RankService;
 import yeolJyeongKong.mall.service.UserService;
 
 import java.util.ArrayList;
@@ -37,6 +38,7 @@ public class UserController {
     private final UserService userService;
     private final ProductService productService;
     private final FavoriteService favoriteService;
+    private final RankService rankService;
 
     @Operation(summary = "마이페이지 조회 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = UserDto.class)))
@@ -240,14 +242,5 @@ public class UserController {
                                                 @PathVariable("mallId") Long mallId) {
         favoriteService.deleteFavoriteMall(userId, mallId);
         return new ResponseEntity<>("즐겨찾기 삭제 완료", HttpStatus.OK);
-    }
-
-    @Operation(summary = "최근 본 상품 업데이트 메소드")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"최근 본 상품 업데이트 완료\"")))
-    @PostMapping("/user/recent/{userId}/{productId}")
-    public ResponseEntity<?> updateRecentProduct(@PathVariable("userId") Long userId,
-                                                 @PathVariable("productId") Long productId) {
-        userService.saveRecentProduct(userId, productId);
-        return new ResponseEntity<>("최근 본 상품 업데이트 완료", HttpStatus.OK);
     }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
@@ -52,6 +53,23 @@ public class UserController {
                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
         userService.infoUpdate(userDto, principalDetails.getUser().getId());
         return new ResponseEntity<>(userDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "비밀번호 수정 메소드")
+    @ApiResponses (value = {
+            @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"비밀번호 변경 성공\""))),
+            @ApiResponse(responseCode = "401", description = "FAIL", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"현재 비밀번호 인증 실패\"")))
+    })
+    @PostMapping("/user/check/password/{password}/{newPassword}")
+    public ResponseEntity<?> checkPassword(@PathVariable("password") String password,
+                                           @PathVariable("newPassword") String newPassword,
+                                           @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        Long userId = principalDetails.getUser().getId();
+        if(userService.passwordCheck(userId, password)) {
+            userService.setPassword(userId, newPassword);
+            return new ResponseEntity<>("비밀번호 변경 성공", HttpStatus.OK);
+        }
+        return new ResponseEntity<>("현재 비밀번호 인증 실패", HttpStatus.UNAUTHORIZED);
     }
 
     @Operation(summary = "체형 정보 조회 메소드")

--- a/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -108,6 +108,18 @@ public class UserController {
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 
+    @Operation(summary = "체형 측정 메소드")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = MeasurementDto.class))))
+    @PostMapping("/user/recommendation/measurement")
+    public ResponseEntity<?> recommendMeasurement(@ModelAttribute ImageDto imageDto,
+                                                  @AuthenticationPrincipal PrincipalDetails principalDetails) {
+        String image = imageDto.getImage(); //request
+        //TODO: API Gateway에 등록된 체형 측정 API에서 체형 측정 결과를 받아오는 로직 필요
+        MeasurementDto measurementDto = null; //response
+        userService.measurementUpdate(measurementDto, principalDetails.getUser().getId());
+        return new ResponseEntity<>(measurementDto, HttpStatus.OK);
+    }
+
     /**
      * <추천 상품 기능 설명>
      * Request  : 해당 유저의 모든 최근 본 상품 정보들

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/dto/ImageDto.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/dto/ImageDto.java
@@ -1,0 +1,12 @@
+package yeolJyeongKong.mall.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@AllArgsConstructor
+@NoArgsConstructor
+public class ImageDto {
+    private String image;
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/dto/MallDto.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/dto/MallDto.java
@@ -11,13 +11,15 @@ public class MallDto {
     private String name;
     private String url;
     private String image;
+    private String description;
     private List<MallRankProductDto> products;
 
     @QueryProjection
-    public MallDto(String name, String url, String image, List<MallRankProductDto> products) {
+    public MallDto(String name, String url, String image, String description, List<MallRankProductDto> products) {
         this.name = name;
         this.url = url;
         this.image = image;
+        this.description = description;
         this.products = products;
     }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/dto/MeasurementDto.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/dto/MeasurementDto.java
@@ -2,6 +2,7 @@ package yeolJyeongKong.mall.domain.dto;
 
 import com.querydsl.core.annotations.QueryProjection;
 import lombok.Getter;
+import yeolJyeongKong.mall.domain.entity.Measurement;
 
 @Getter
 public class MeasurementDto {
@@ -27,5 +28,17 @@ public class MeasurementDto {
         this.chest = chest;
         this.thigh = thigh;
         this.hip = hip;
+    }
+
+    public MeasurementDto(Measurement measurement) {
+        this.height = measurement.getHeight();
+        this.weight = measurement.getWeight();
+        this.arm = measurement.getArm();
+        this.leg = measurement.getLeg();
+        this.shoulder = measurement.getShoulder();
+        this.waist = measurement.getWaist();
+        this.chest = measurement.getChest();
+        this.thigh = measurement.getThigh();
+        this.hip = measurement.getHip();
     }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/dto/MeasurementDto.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/dto/MeasurementDto.java
@@ -5,7 +5,6 @@ import lombok.Getter;
 
 @Getter
 public class MeasurementDto {
-    private String username;
     private Integer height;
     private Integer weight;
     private Integer arm;
@@ -17,9 +16,8 @@ public class MeasurementDto {
     private Integer hip;
 
     @QueryProjection
-    public MeasurementDto(String username, Integer height, Integer weight, Integer arm, Integer leg,
-                          Integer shoulder, Integer waist, Integer chest, Integer thigh, Integer hip) {
-        this.username = username;
+    public MeasurementDto(Integer height, Integer weight, Integer arm, Integer leg, Integer shoulder,
+                          Integer waist, Integer chest, Integer thigh, Integer hip) {
         this.height = height;
         this.weight = weight;
         this.arm = arm;

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/dto/ProductDetailDto.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/dto/ProductDetailDto.java
@@ -1,0 +1,21 @@
+package yeolJyeongKong.mall.domain.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class ProductDetailDto {
+    private Integer price;
+    private String name;
+    private String gender;
+    private Integer type;
+    private String image;
+    private String descriptionImage;
+    private String categoryName;
+    private String mallName;
+    private List<TopDto> topSizes;
+    private List<BottomDto> bottomSizes;
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Bottom.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Bottom.java
@@ -2,12 +2,16 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import yeolJyeongKong.mall.domain.dto.BottomDto;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Bottom {
 
     @Id @GeneratedValue
@@ -33,4 +37,13 @@ public class Bottom {
 
     @OneToOne(mappedBy = "bottom", fetch = LAZY)
     private Size size;
+
+    public Bottom(BottomDto bottomDto) {
+        this.full = bottomDto.getFull();
+        this.waist = bottomDto.getWaist();
+        this.thigh = bottomDto.getThigh();
+        this.rise = bottomDto.getRise();
+        this.bottomWidth = bottomDto.getBottomWidth();
+        this.hipWidth = bottomDto.getHipWidth();
+    }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Category.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Category.java
@@ -2,14 +2,18 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.hibernate.validator.constraints.Length;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static lombok.AccessLevel.PROTECTED;
+
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Category {
 
     @Id @GeneratedValue
@@ -21,4 +25,8 @@ public class Category {
 
     @OneToMany(mappedBy = "category")
     private List<Product> products = new ArrayList<>();
+
+    public Category(String name) {
+        this.name = name;
+    }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Mall.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Mall.java
@@ -2,16 +2,20 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.hibernate.validator.constraints.Length;
+import yeolJyeongKong.mall.domain.dto.MallDto;
 
 import java.util.ArrayList;
 import java.util.List;
 
 import static jakarta.persistence.FetchType.*;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Mall {
 
     @Id @GeneratedValue
@@ -37,4 +41,11 @@ public class Mall {
 
     @OneToMany(mappedBy = "mall")
     private List<Favorite> favorites = new ArrayList<>();
+
+    public Mall(MallDto mallDto) {
+        this.name = mallDto.getName();
+        this.url = mallDto.getUrl();
+        this.image = mallDto.getImage();
+        this.description = mallDto.getDescription();
+    }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Measurement.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Measurement.java
@@ -2,13 +2,16 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import yeolJyeongKong.mall.domain.dto.MeasurementDto;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Measurement {
 
     @Id @GeneratedValue
@@ -31,6 +34,10 @@ public class Measurement {
 
     @OneToOne(mappedBy = "measurement", fetch = LAZY)
     private User user;
+
+    public Measurement(User user) {
+        this.user = user;
+    }
 
     public void update(MeasurementDto measurementDto) {
         height = measurementDto.getHeight();

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
@@ -2,6 +2,7 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.hibernate.validator.constraints.Length;
 
@@ -9,9 +10,11 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Product {
 
     @Id @GeneratedValue
@@ -72,6 +75,15 @@ public class Product {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "recent_recommendation_id")
     private RecentRecommendation recentRecommendation;
+
+    public Product(Category category, Mall mall) {
+        this.category = category;
+        this.mall = mall;
+    }
+
+    public void setSizes(List<Size> sizes) {
+        this.sizes = sizes;
+    }
 
     public void updateView() {
         view = view + 1;

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Rank.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Rank.java
@@ -2,13 +2,16 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
 @Table(name = "`rank`")
+@NoArgsConstructor(access = PROTECTED)
 public class Rank {
 
     @Id @GeneratedValue
@@ -25,4 +28,14 @@ public class Rank {
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "mall_id")
     private Mall mall;
+
+    public Rank(User user, Mall mall) {
+        this.user = user;
+        this.mall = mall;
+        view = 0L;
+    }
+
+    public void updateView() {
+        view++;
+    }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
@@ -2,13 +2,18 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
 import org.hibernate.validator.constraints.Length;
+import yeolJyeongKong.mall.domain.dto.BottomDto;
+import yeolJyeongKong.mall.domain.dto.TopDto;
 
 import static jakarta.persistence.FetchType.*;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Size {
 
     @Id @GeneratedValue
@@ -29,4 +34,18 @@ public class Size {
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "product_id")
     private Product product;
+
+    public Size(TopDto topDto) {
+        this.name = topDto.getName();
+        this.top = new Top(topDto);
+    }
+
+    public Size(BottomDto bottomDto) {
+        this.name = bottomDto.getName();
+        this.bottom = new Bottom(bottomDto);
+    }
+
+    public void setProduct(Product product) {
+        this.product = product;
+    }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Top.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/Top.java
@@ -2,12 +2,16 @@ package yeolJyeongKong.mall.domain.entity;
 
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.NonNull;
+import yeolJyeongKong.mall.domain.dto.TopDto;
 
 import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
 
 @Entity
 @Getter
+@NoArgsConstructor(access = PROTECTED)
 public class Top {
 
     @Id @GeneratedValue
@@ -27,4 +31,11 @@ public class Top {
 
     @OneToOne(mappedBy = "top", fetch = LAZY)
     private Size size;
+
+    public Top(TopDto topDto) {
+        this.full = topDto.getFull();
+        this.shoulder = topDto.getShoulder();
+        this.chest = topDto.getChest();
+        this.sleeve = topDto.getSleeve();
+    }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
@@ -24,10 +24,10 @@ public class User {
     @Column(name = "user_id")
     private Long id;
 
-    @NonNull @Length(max = 10)
+    @NonNull @Length(max = 20)
     private String username;
 
-    @NonNull @Length(min = 8, max = 15)
+    @NonNull
     private String password;
 
     @NonNull @Length(min = 7, max = 64)
@@ -63,6 +63,10 @@ public class User {
     @ElementCollection(fetch = EAGER)
     private List<String> roles = new ArrayList<>();
 
+    private String provider;
+    private String providerId;
+    private String providerLoginId; //{provider}_{providerId}
+
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "measurement_id")
     private Measurement measurement;
@@ -91,6 +95,15 @@ public class User {
         day = signUpDto.getDay();
         ageRange = getAgeRange(year, month, day);
         this.password = password;
+        roles.add("USER");
+    }
+
+    public User(String email, String provider, String providerId) {
+        username = email.substring(0, email.indexOf('@'));
+        providerLoginId = provider + "_" + providerId;
+        this.email = email;
+        this.provider = provider;
+        this.providerId = providerId;
         roles.add("USER");
     }
 

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
@@ -96,6 +96,9 @@ public class User {
         ageRange = getAgeRange(year, month, day);
         this.password = password;
         roles.add("USER");
+
+        measurement = new Measurement(this);
+
     }
 
     public User(String email, String provider, String providerId) {
@@ -105,6 +108,8 @@ public class User {
         this.provider = provider;
         this.providerId = providerId;
         roles.add("USER");
+
+        measurement = new Measurement(this);
     }
 
     public void update(UserDto userDto) {

--- a/mall/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
@@ -115,6 +115,10 @@ public class User {
         day = userDto.getDay();
     }
 
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
     private Integer getAgeRange(Integer year, Integer month, Integer day) {
         LocalDate birthDate = LocalDate.of(year, month, day);
         LocalDate currentDate = LocalDate.now();

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/CategoryRepository.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/CategoryRepository.java
@@ -3,5 +3,8 @@ package yeolJyeongKong.mall.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yeolJyeongKong.mall.domain.entity.Category;
 
+import java.util.Optional;
+
 public interface CategoryRepository extends JpaRepository<Category, Long> {
+    Optional<Category> findByName(String name);
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/MallRepository.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/MallRepository.java
@@ -3,5 +3,8 @@ package yeolJyeongKong.mall.repository;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yeolJyeongKong.mall.domain.entity.Mall;
 
+import java.util.Optional;
+
 public interface MallRepository extends JpaRepository<Mall, Long> {
+    Optional<Mall> findByName(String name);
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/RankRepository.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/RankRepository.java
@@ -4,5 +4,8 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import yeolJyeongKong.mall.domain.entity.Rank;
 import yeolJyeongKong.mall.repository.querydsl.RankRepositoryCustom;
 
+import java.util.Optional;
+
 public interface RankRepository extends JpaRepository<Rank, Long>, RankRepositoryCustom {
+    Optional<Rank> findByUserIdAndMallId(Long userId, Long mallId);
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/SizeRepository.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/SizeRepository.java
@@ -1,0 +1,7 @@
+package yeolJyeongKong.mall.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yeolJyeongKong.mall.domain.entity.Size;
+
+public interface SizeRepository extends JpaRepository<Size, Long> {
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/UserRepository.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long>, UserRepositoryCustom {
     Optional<User> findByEmail(String email);
+    Optional<User> findByProviderLoginId(String providerLoginId);
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/querydsl/RankRepositoryImpl.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/querydsl/RankRepositoryImpl.java
@@ -7,13 +7,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import yeolJyeongKong.mall.domain.dto.*;
 import yeolJyeongKong.mall.domain.entity.*;
-import yeolJyeongKong.mall.repository.ProductRepository;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static yeolJyeongKong.mall.domain.entity.QMall.mall;
-import static yeolJyeongKong.mall.domain.entity.QProduct.product;
 import static yeolJyeongKong.mall.domain.entity.QRank.rank;
 import static yeolJyeongKong.mall.domain.entity.QUser.user;
 

--- a/mall/src/main/java/yeolJyeongKong/mall/repository/querydsl/UserRepositoryImpl.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/repository/querydsl/UserRepositoryImpl.java
@@ -38,7 +38,6 @@ public class UserRepositoryImpl implements UserRepositoryCustom {
     public MeasurementDto measurementInfo(Long userId) {
         return queryFactory
                 .select(new QMeasurementDto(
-                        user.username,
                         measurement.height,
                         measurement.weight,
                         measurement.arm,

--- a/mall/src/main/java/yeolJyeongKong/mall/service/CategoryService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/CategoryService.java
@@ -1,0 +1,23 @@
+package yeolJyeongKong.mall.service;
+
+import jakarta.persistence.NoResultException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yeolJyeongKong.mall.domain.entity.Category;
+import yeolJyeongKong.mall.repository.CategoryRepository;
+
+@Service
+@RequiredArgsConstructor
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public void save(String categoryName) {
+        categoryRepository.save(new Category(categoryName));
+    }
+
+    public Category findByName(String categoryName) {
+        return categoryRepository.findByName(categoryName)
+                .orElseThrow(() -> new NoResultException("category dosen't exist"));
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/service/FavoriteService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/FavoriteService.java
@@ -52,7 +52,7 @@ public class FavoriteService {
                 productDtos.add(new MallRankProductDto(product.getId(), product.getImage()));
             }
 
-            result.add(new MallDto(mall.getName(), mall.getUrl(), mall.getImage(), productDtos));
+            result.add(new MallDto(mall.getName(), mall.getUrl(), mall.getImage(), mall.getDescription(), productDtos));
         }
 
         return result;

--- a/mall/src/main/java/yeolJyeongKong/mall/service/FavoriteService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/FavoriteService.java
@@ -42,11 +42,9 @@ public class FavoriteService {
             List<Product> products = mall.getProducts();
             List<MallRankProductDto> productDtos = new ArrayList<>();
 
-            /**
-             * 해당 쇼핑몰에서 노출시킬 상품 개수 설정 필요
-             * 현재는 전부로 설정
-             */
+            int productCount = 0;
             for (Product productProxy : products) {
+                if(productCount++ == 5) break;
                 Product product = productRepository.findById(productProxy.getId())
                         .orElseThrow(() -> new NoResultException("product dosen't exist"));
                 productDtos.add(new MallRankProductDto(product.getId(), product.getImage()));

--- a/mall/src/main/java/yeolJyeongKong/mall/service/MallService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/MallService.java
@@ -1,0 +1,24 @@
+package yeolJyeongKong.mall.service;
+
+import jakarta.persistence.NoResultException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yeolJyeongKong.mall.domain.dto.MallDto;
+import yeolJyeongKong.mall.domain.entity.Mall;
+import yeolJyeongKong.mall.repository.MallRepository;
+
+@Service
+@RequiredArgsConstructor
+public class MallService {
+
+    private final MallRepository mallRepository;
+
+    public void save(MallDto mallDto) {
+        mallRepository.save(new Mall(mallDto));
+    }
+
+    public Mall findByName(String mallName) {
+        return mallRepository.findByName(mallName)
+                .orElseThrow(() -> new NoResultException("mall dosen't exist"));
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/service/ProductService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/ProductService.java
@@ -7,10 +7,7 @@ import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-import yeolJyeongKong.mall.domain.dto.BottomProductDto;
-import yeolJyeongKong.mall.domain.dto.ProductCategoryDto;
-import yeolJyeongKong.mall.domain.dto.ProductPreviewDto;
-import yeolJyeongKong.mall.domain.dto.TopProductDto;
+import yeolJyeongKong.mall.domain.dto.*;
 import yeolJyeongKong.mall.domain.entity.*;
 import yeolJyeongKong.mall.repository.*;
 
@@ -27,6 +24,11 @@ public class ProductService {
     private final MallRepository mallRepository;
     private final RecentRecommendationRepository recentRecommendationRepository;
     private final UserRecommendationRepository userRecommendationRepository;
+
+    @Transactional
+    public void save(Product product) {
+        productRepository.save(product);
+    }
 
     @Cacheable(value = "Product", key = "#productId")
     public Product findById(Long productId) {

--- a/mall/src/main/java/yeolJyeongKong/mall/service/RankService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/RankService.java
@@ -1,34 +1,34 @@
 package yeolJyeongKong.mall.service;
 
 import jakarta.persistence.NoResultException;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import yeolJyeongKong.mall.domain.dto.MallPreviewDto;
 import yeolJyeongKong.mall.domain.dto.MallDto;
 import yeolJyeongKong.mall.domain.dto.MallRankProductDto;
-import yeolJyeongKong.mall.domain.entity.Mall;
-import yeolJyeongKong.mall.domain.entity.Product;
-import yeolJyeongKong.mall.domain.entity.QProduct;
+import yeolJyeongKong.mall.domain.entity.*;
+import yeolJyeongKong.mall.repository.MallRepository;
 import yeolJyeongKong.mall.repository.ProductRepository;
 import yeolJyeongKong.mall.repository.RankRepository;
+import yeolJyeongKong.mall.repository.UserRepository;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 
-import static yeolJyeongKong.mall.domain.entity.QProduct.product;
-
 @Service
 @RequiredArgsConstructor
 public class RankService {
 
+    private final UserRepository userRepository;
+    private final MallRepository mallRepository;
     private final RankRepository rankRepository;
     private final ProductRepository productRepository;
 
     public List<MallDto> mallRank(Long userId) {
         List<Mall> malls = rankRepository.mallRank(userId);
-
         List<MallDto> result = new ArrayList<>();
 
         for (Mall mall : malls) {
@@ -46,7 +46,7 @@ public class RankService {
                 productDtos.add(new MallRankProductDto(product.getId(), product.getImage()));
             }
 
-            result.add(new MallDto(mall.getName(), mall.getUrl(), mall.getImage(), productDtos));
+            result.add(new MallDto(mall.getName(), mall.getUrl(), mall.getImage(), mall.getDescription(), productDtos));
         }
 
         return result;
@@ -54,5 +54,25 @@ public class RankService {
 
     public List<MallPreviewDto> mallRankPreview(Long userId, Pageable pageable, int count) {
         return rankRepository.mallRankPreview(userId, pageable, count);
+    }
+
+    @Transactional
+    public void updateView(Long userId, Long productId) {
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new NoResultException("product doesn't exist"));
+        Optional<Rank> optionalRank = rankRepository.findByUserIdAndMallId(userId, product.getMall().getId());
+        Rank rank = null;
+
+        if(optionalRank.isPresent()) {
+            rank = optionalRank.get();
+        } else {
+            User user = userRepository.findById(userId)
+                    .orElseThrow(() -> new NoResultException("user doesn't exist"));
+            Mall mall = mallRepository.findById(product.getMall().getId())
+                    .orElseThrow(() -> new NoResultException("mall doesn't exist"));
+            rank = new Rank(user, mall);
+        }
+
+        rank.updateView();
     }
 }

--- a/mall/src/main/java/yeolJyeongKong/mall/service/SizeService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/SizeService.java
@@ -1,0 +1,32 @@
+package yeolJyeongKong.mall.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import yeolJyeongKong.mall.domain.dto.BottomDto;
+import yeolJyeongKong.mall.domain.dto.TopDto;
+import yeolJyeongKong.mall.domain.entity.Product;
+import yeolJyeongKong.mall.domain.entity.Size;
+import yeolJyeongKong.mall.repository.SizeRepository;
+
+@Service
+@RequiredArgsConstructor
+public class SizeService {
+
+    private final SizeRepository sizeRepository;
+
+    public Size saveTop(TopDto topDto) {
+        Size size = new Size(topDto);
+        sizeRepository.save(size);
+        return size;
+    }
+
+    public Size saveBottom(BottomDto bottomDto) {
+        Size size = new Size(bottomDto);
+        sizeRepository.save(new Size(bottomDto));
+        return size;
+    }
+
+    public void setProduct(Size size, Product product) {
+        size.setProduct(product);
+    }
+}

--- a/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
@@ -1,5 +1,6 @@
 package yeolJyeongKong.mall.service;
 
+import com.querydsl.core.NonUniqueResultException;
 import jakarta.persistence.NoResultException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -65,7 +66,13 @@ public class UserService {
     }
 
     public MeasurementDto measurementInfo(Long userId) {
-        return userRepository.measurementInfo(userId);
+        try {
+            return userRepository.measurementInfo(userId);
+        } catch (NonUniqueResultException e) {
+            //Measurement 생성해서 User와 연결해주기
+            MeasurementDto measurementDto = null;
+            return measurementDto;
+        }
     }
 
     @Transactional

--- a/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
@@ -66,13 +66,7 @@ public class UserService {
     }
 
     public MeasurementDto measurementInfo(Long userId) {
-        try {
-            return userRepository.measurementInfo(userId);
-        } catch (NonUniqueResultException e) {
-            //Measurement 생성해서 User와 연결해주기
-            MeasurementDto measurementDto = null;
-            return measurementDto;
-        }
+        return userRepository.measurementInfo(userId);
     }
 
     @Transactional

--- a/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
@@ -54,6 +54,16 @@ public class UserService {
         user.update(userDto);
     }
 
+    public boolean passwordCheck(Long userId, String inputPassword) {
+        String password = findById(userId).getPassword();
+        return passwordEncoder.matches(inputPassword, password);
+    }
+
+    public void setPassword(Long userId, String newPassword) {
+        User user = findById(userId);
+        user.setPassword(passwordEncoder.encode(newPassword));
+    }
+
     public MeasurementDto measurementInfo(Long userId) {
         return userRepository.measurementInfo(userId);
     }

--- a/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
+++ b/mall/src/main/java/yeolJyeongKong/mall/service/UserService.java
@@ -95,6 +95,24 @@ public class UserService {
         recent.get().update(product);
     }
 
+    @Transactional
+    public void saveFavoriteProduct(Long userId, Long productId) {
+        User user = findById(userId);
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new NoResultException("product dosen't exist"));
+
+        user.getProducts().add(product);
+    }
+
+    @Transactional
+    public void deleteFavoriteProduct(Long userId, Long productId) {
+        User user = findById(userId);
+        Product product = productRepository.findById(productId)
+                .orElseThrow(() -> new NoResultException("product dosen't exist"));
+
+        user.getProducts().remove(product);
+    }
+
     public User login(LoginDto loginDto) {
         User user = userRepository.findByEmail(loginDto.getEmail())
                 .orElseThrow(() -> new NoResultException("User doesn't exist"));


### PR DESCRIPTION
### 추천 상품 기능 캐시 적용
추천 기능을 통해 받아오는 상품 정보는 일정 주기를 둬서 갱신할 예정이므로 **다음 갱신까지는 불러왔던 상품 정보를 DB에 저장한 뒤 캐시로 관리해** 사용자로의 전송 속도를 빠르게 유지하려고 합니다. 초기화 주기를 아직 설정하지 않았기 때문에 해당 주기에 맞춰서 `@CacheEvict`를 등록해 캐시를 비우게 만들 예정입니다.
```java
@Cacheable(value = "recommendation", key = "#userId")
public List<Long> findRecommendedProductIds(Long userId) {...}

@Cacheable(value = "recommendationOnPick", key = "#userId")
public List<Long> findRecommendedProductIdsOnPick(Long userId) {...}
```
- [feat: 추천 상품 불러올 때 캐시 적용](https://github.com/YeolJyeongKong/fittering-BE/commit/fa1458899fc5694c741478f7956556bb23163e18)

### OAuth2 적용
**구글, 카카오**에 한해서 소셜 로그인 기능 구현 및 테스트 완료했습니다. 로그인 ID는 `email`을 사용할 예정이므로 `email` 정보만 가져오도록 설정했습니다. 추후 애플 소셜 로그인 기능도 구현할 예정입니다.
- 구현 내용 : [[Spring] OAuth2 로그인 구현하기 - 구글, 카카오](https://yooniversal.github.io/project/post229/)
- [feat: 구글, 카카오 OAuth2 적용](https://github.com/YeolJyeongKong/fittering-BE/commit/a0cb25f5e63b31053169055e19f177a94cc51fd4)
- 트러블 슈팅
  + [[Spring] Could not commit JPA transaction](https://yooniversal.github.io/project/post228/)
  + [[OAuth2] This class supports client_secret_basic, client_secret_post, and none by default](https://yooniversal.github.io/project/post227/)

### 이외
- 각 엔티티를 활용해서 데이터를 제공하거나 삭제하는 로직은 이전에 구현했지만 생성하는 내용이 없어 추가
  + [feat: 엔티티 생성 부분 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/f6513f4078f2beb7408198e79f3b9141b1be0d49)
- 즐겨찾기 쇼핑몰 정보에 노출될 상품 개수를 **5개**로 설정
  + [feat: 유저 즐겨찾기 쇼핑몰 노출 상품 개수 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/d9b95d513519d7343cc7cc53007474c129d24183)

## API 구현
### 비밀번호 변경
유저의 비밀번호 변경 기능을 지원할 수 있도록 API 구현했습니다.
- HTTP 메소드 : `POST`
- 주소 : `/user/check/password/{password}/{newPassword}`
- [feat: 비밀번호 변경 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/0e42775a0e2629c4e3e815d1d871e3c5c9357fce)

### 체형 측정 (부분 구현)
ML 모델로 유저의 전신 사진을 넣었을 때 본인의 체형 정보를 바로 알 수 있도록 하는 **스마트 체형 측정 기능에 적용될 API**로, ML 모델로의 API를 사용해서 response를 받아와 그대로 반환할 예정입니다. ML 모델을 거치는 API가 아직 미구현 상태이므로 이에 해당되는 부분만 구현하지 않았습니다. 추후 구현되는대로 수정할 예정입니다.
- HTTP 메소드 : `POST`
- 주소 : `/user/recommendation/measurement`
- [feat: 체형 측정 API 부분 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/72af24764cf0427381ecc272892045b8ae7e5330)

### 좋아요 누른 상품 (등록/삭제)
유저가 좋아요 누른 상품에 대해 괸리 및 목록에서 삭제할 수 있게하는 API 구현했습니다.
- HTTP 메소드 : `POST`, `DELETE`
- 주소 : `/user/favorite_goods/{productId}`
- [feat: 유저 좋아요 상품 등록/삭제 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/363fd57f40d234e6f8eba978507e45ab59ec6cca)
