### PR TITLE
CD : secrets 참조 에러

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,16 +64,16 @@ jobs:
 
       # application.yml
       - name: make application.yml
-        env:
-          APPLICATION: ${{ secrets.APP_SECRET }}
         run: touch ./src/main/resources/application.yml
       - name: deliver application.yml
+        env:
+            APPLICATION: ${{ secrets.APP_SECRET }}
         run: echo $APPLICATION >> ./src/main/resources/application.yml
 
       # application-oauth.yml
       - name: make application-oauth.yml
-        env:
-          APPLICATION_OAUTH: ${{ secrets.APP_OAUTH_SECRET }}
         run: touch ./src/main/resources/application-oauth.yml
       - name: deliver application-oauth.yml
+        env:
+          APPLICATION_OAUTH: ${{ secrets.APP_OAUTH_SECRET }}
         run: echo $APPLICATION_OAUTH >> ./src/main/resources/application-oauth.yml

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -63,17 +63,17 @@ jobs:
             --s3-location bucket=$S3_BUCKET_NAME,key=$GITHUB_SHA.zip,bundleType=zip
 
       # application.yml
-      - name:  make application.yml
+      - name: make application.yml
+        env:
+          APPLICATION: ${{ secrets.APP_SECRET }}
         run: touch ./src/main/resources/application.yml
-        shell: bash
       - name: deliver application.yml
-        run: echo "${{ secrets.APP_SECRET }}" > ./src/main/resources/application.yml
-        shell: bash
+        run: echo $APPLICATION >> ./src/main/resources/application.yml
 
       # application-oauth.yml
       - name: make application-oauth.yml
+        env:
+          APPLICATION_OAUTH: ${{ secrets.APP_OAUTH_SECRET }}
         run: touch ./src/main/resources/application-oauth.yml
-        shell: bash
       - name: deliver application-oauth.yml
-        run: echo "${{ secrets.APP_OAUTH_SECRET }}" > ./src/main/resources/application-oauth.yml
-        shell: bash
+        run: echo $APPLICATION_OAUTH >> ./src/main/resources/application-oauth.yml


### PR DESCRIPTION
### secrets 참조 에러
`secrets`에 저장했던 `application.yml`, `application-oauth.yml` 정보를 직접 참조해서 사용했는데 다음 에러가 발생했습니다.
```
echo "***
    ***
          **
...
      ***
  " > ./src/main/resources/application.yml
  shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
  env:
    AWS_REGION: ap-northeast-2
    S3_BUCKET_NAME: fittering-bucket-test
    CODE_DEPLOY_APPLICATION_NAME: fittering-codedeploy-app
    CODE_DEPLOY_DEPLOYMENT_GROUP_NAME: fittering-codedeploy-group
    JAVA_HOME: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.7-7/x64
    JAVA_HOME_17_X64: /opt/hostedtoolcache/Java_Temurin-Hotspot_jdk/17.0.7-7/x64
    GRADLE_BUILD_ACTION_CACHE_RESTORED: true
    AWS_DEFAULT_REGION: ap-northeast-2
    AWS_ACCESS_KEY_ID: ***
    AWS_SECRET_ACCESS_KEY: ***
/home/runner/work/_temp/103966c5-f671-435c-bc34-a73f8c8b58c9.sh: line 100: ***
...
      ***
: bad substitution
Error: Process completed with exit code 1.
```

아래는 `deploy.yml`에서 문제가 발생한 코드입니다.
`${{ secrets.APP_SECRET }}`에서 위 에러가 발생했습니다.
```
...
# application.yml
- name:  make application.yml
  run: touch ./src/main/resources/application.yml
  shell: bash
- name: deliver application.yml
  run: echo "${{ secrets.APP_SECRET }}" > ./src/main/resources/application.yml # **문제 발생**
  shell: bash
```

[actions/runner](https://github.com/actions/runner)에서 이와 비슷한 문제를 다루는 issue가 있는걸 확인했고 **인식을 제대로 하지못해 발생하는 문제**로 보입니다.
임시 방편으로 참조하려는 내용을 환경변수 `env`에 저장한 후 사용하면 해결할 수 있다는 언급이 있어 그렇게 수정했습니다.
```yml
- name: deliver application.yml
  env:
    APPLICATION: ${{ secrets.APP_SECRET }}
  run: echo $APPLICATION >> ./src/main/resources/application.yml
```
- [fix: 환경변수에 secrets 저장 후 참조](https://github.com/YeolJyeongKong/fittering-BE/commit/6c1fb29db368191117eede991fd5eefbef722316)
- [fix: 환경변수 선언 위치 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/fdd37a8a5207ef9fd7e2c1dd668478943345ed4a)

### References
- [actions/runner : github.action_path contains wrong path when used inside a container #2185](https://github.com/actions/runner/issues/2185)
- [actions/runner : ${{ github.action_path }} makes no sense when action is run inside self-hosted custom container. #716](https://github.com/actions/runner/issues/716)