### PR TITLE
CD : docker compose 등록

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -24,15 +24,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Install Docker Compose
-        run: |
-          sudo curl -L "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/bin/docker-compose
-          sudo chmod +x /usr/local/bin/docker-compose
-
-      - name: Build and run with Docker Compose
-        run: |
-          docker-compose up -d
-
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -20,3 +20,8 @@ nohup java -jar $JAR_FILE > $APP_LOG 2> $ERROR_LOG &
 
 CURRENT_PID=$(pgrep -f $JAR_FILE)
 echo "$TIME_NOW > 실행된 프로세스 아이디 $CURRENT_PID 입니다." >> $DEPLOY_LOG
+
+# docker-compose 실행
+echo "$TIME_NOW > Docker Compose Up" >> $DEPLOY_LOG
+cd $PROJECT_ROOT
+docker-compose up -d

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -18,3 +18,8 @@ else
   echo "$TIME_NOW > 실행중인 $CURRENT_PID 애플리케이션 종료 " >> $DEPLOY_LOG
   kill -15 $CURRENT_PID
 fi
+
+# docker-compose 닫기
+echo "$TIME_NOW > Docker Compose Down" >> $DEPLOY_LOG
+cd $PROJECT_ROOT
+docker-compose down -v


### PR DESCRIPTION
### Problem
Github Actions를 통해 EC2로 배포된 `jar` 파일 실행 시 프로젝트 내부 로직 중 **redis 캐시 애노테이션이 포함돼** 문제가 발생하고 있었습니다.
다음은 발생한 에러 로그 일부입니다.
```
2023-07-27T05:18:38.762Z  INFO 24269 --- [           main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface yeolJyeongKong.mall.repository.FavoriteRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
2023-07-27T05:18:38.763Z  INFO 24269 --- [           main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface yeolJyeongKong.mall.repository.RecentRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
2023-07-27T05:18:38.763Z  INFO 24269 --- [           main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface yeolJyeongKong.mall.repository.TopRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
2023-07-27T05:18:38.767Z  INFO 24269 --- [           main] .RepositoryConfigurationExtensionSupport : Spring Data Redis - Could not safely identify store assignment for repository candidate interface yeolJyeongKong.mall.repository.CategoryRepository; If you want this repository to be a Redis repository, consider annotating your entities with one of these annotations: org.springframework.data.redis.core.RedisHash (preferred), or consider extending one of the following types with your repository: org.springframework.data.keyvalue.repository.KeyValueRepository
...
```
<br>

Github Actions에서 활용될 `deploy.yml`에서 `docker-compose.yml`을 빌드 후 실행하는 로직을 추가했었으나 `volume` 설정에서 문제가 발생했고, docker container를 띄우는 작업을 workflow에서 처리하기 어렵다고 판단했습니다. 다음은 발생했던 에러 로그입니다.
```
Error response from daemon: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: error during container init: error mounting "/home/ubuntu/app/src/main/resources/prometheus.yml" to rootfs at "/etc/prometheus/prometheus.yml": mount /home/ubuntu/app/src/main/resources/prometheus.yml:/etc/prometheus/prometheus.yml (via /proc/self/fd/6), flags: 0x5000: not a directory: unknown: Are you trying to mount a directory onto a file (or vice-versa)? Check if the specified host path exists and is the expected type
Error: Process completed with exit code 1.
```
- [feat: 배포 시 docker compose 설치 및 실행](https://github.com/YeolJyeongKong/fittering-BE/commit/401190ea121302c9b76ca61aff1adfe881904be9)
- [fix: docker compose 설치 및 실행 로직 삭제](https://github.com/YeolJyeongKong/fittering-BE/commit/1e9f5a401241f2931a2055c3ca0760017f71c7ed)

### Resolved
`redis`, `prometheus`, `grafana`를 docker container로 한번에 띄울 수 있도록 `docker-compose.yml` 작성했습니다.
`prometheus`에서 volumes에 적용된된 `prometheus.yml`은 프로젝트 내 `src/main/resources/prometheus.yml`을 의미합니다.
```
redis:
    image: redis
    container_name: redis-cache
    ports:
      - 6379:6379
    restart: unless-stopped

  grafana:
    image: grafana/grafana
    container_name: grafana-container
    ports:
      - "3000:3000"
    restart: unless-stopped

  prometheus:
    image: prom/prometheus
    container_name: prometheus-container
    ports:
      - "9090:9090"
    volumes:
      - /home/ubuntu/app/src/main/resources/prometheus.yml:/etc/prometheus/prometheus.yml
    restart: unless-stopped
```
- [feat: docker container로 띄울 서비스 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/7d0d37529456c06e88d01a198298885931bf7518)

docker compose 실행 관리를 Github Actions에서 처리하지 않고, `appspec.yml`에 의해 배포할 때마다 실행되는 `start.sh`, `stop.sh`를 수정해 `docker-compose.yml` 실행 및 중단하도록 설정했습니다.
```sh
# start.sh
echo "$TIME_NOW > Docker Compose Up" >> $DEPLOY_LOG
cd $PROJECT_ROOT
docker-compose up -d 

# stop.sh
echo "$TIME_NOW > Docker Compose Down" >> $DEPLOY_LOG
cd $PROJECT_ROOT
docker-compose down -v
```
- [feat: docker compose 실행 로직 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/c8e92e76b66a5b6f1dd031e92706c194221748ba)
- [feat: docker compose 종료 로직 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/e528c5023f66c1c128dda5e2b0d12603c487fd90)