### PR TITLE
CD : redisConfig 빈 생성 불가

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -30,11 +30,11 @@ jobs:
           distribution: 'temurin'
           java-version: '17'
 
-      # Test 제외
-      - name: Build with Gradle
-        uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
-        with:
-          arguments: clean build -x test
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Clean and Build with Gradle
+        run: ./gradlew clean build
 
       # AWS 인증
       - name: Configure AWS credentials


### PR DESCRIPTION
### Problem
EC2에 빌드를 통해 생성된 `jar` 파일을 직접 명령어로 실행 시 다음과 같은 에러 메시지를 출력하고 종료됩니다.
로컬에서 같은 과정으로 생성된 `jar` 파일 실행 시에는 에러가 발생하지 않습니다. 
```
2023-07-27T13:11:41.036Z  INFO 1876 --- [           main] o.a.c.c.C.[Tomcat].[localhost].[/]       : Initializing Spring embedded WebApplicationContext
2023-07-27T13:11:41.043Z  INFO 1876 --- [           main] w.s.c.ServletWebServerApplicationContext : Root WebApplicationContext: initialization completed in 6573 ms
2023-07-27T13:11:42.053Z  WARN 1876 --- [           main] ConfigServletWebServerApplicationContext : Exception encountered during context initialization - cancelling refresh attempt: org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cacheManager' defined in class path resource [org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.class]: Unsatisfied dependency expressed through method 'cacheManager' parameter 4: Error creating bean with name 'redisConfig': Injection of autowired dependencies failed
2023-07-27T13:11:42.066Z  INFO 1876 --- [           main] o.apache.catalina.core.StandardService   : Stopping service [Tomcat]
...
org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'cacheManager' defined in class path resource [org/springframework/boot/autoconfigure/cache/RedisCacheConfiguration.class]: Unsatisfied dependency expressed through method 'cacheManager' parameter 4: Error creating bean with name 'redisConfig': Injection of autowired dependencies failed
Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'redisConfig': Injection of autowired dependencies failed
Caused by: java.lang.IllegalArgumentException: Could not resolve placeholder 'spring.data.redis.host' in value "${spring.data.redis.host}"
```
- `cacheManager` 빈 생성 불가
- `application.yml`에 등록된 `${spring.data.redis.host}`을 가져오지 못하고 있음

로컬에서 `application.yml`를 통해 테스트 해본 결과 `application.yml`이 없을 때 위 문제가 발생하는걸 확인했습니다.

### Resolved
기존 빌드 방식은 테스트 과정을 거치지 않습니다. 하지만 테스트를 거치지 않고 빌드를 하는 경우 `application.yml`이 없어도
성공하게 돼 **`application.yml`이 실제로 있는지 여부를 확인할 수 없는 문제**가 있어 테스트 과정을 추가했습니다.
빌드 실패 시, `application.yml`이 생성되지 않았거나 정상적인 값을 갖고있지 않아 발생하는 문제임을 확인할 수 있습니다.
```yml
# Before
- name: Build with Gradle
  uses: gradle/gradle-build-action@0d13054264b0bb894ded474f08ebb30921341cee
  with:
    arguments: clean build -x test

# After
- name: Grant execute permission for gradlew
  run: chmod +x gradlew
- name: Clean and Build with Gradle
  run: ./gradlew clean build
```
- [fix: 빌드 방식 변경](https://github.com/YeolJyeongKong/fittering-BE/commit/fd11e95c660acc1a4301c3326879273dcb55c89f)
- [fix: workflow job 실행 순서 변경](https://github.com/YeolJyeongKong/fittering-BE/commit/5ec2d8c15aeee5c7c673115ff44c94c8cc5653a6)