### PR TITLE
전체 API 테스트

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -46,6 +46,8 @@ dependencies {
 
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 	implementation 'org.springframework.boot:spring-boot-starter-cache'
+	implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
 
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
 	implementation 'io.micrometer:micrometer-core'

--- a/src/main/java/yeolJyeongKong/mall/controller/MallController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/MallController.java
@@ -12,10 +12,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 import yeolJyeongKong.mall.config.PrincipalDetails;
 import yeolJyeongKong.mall.domain.dto.MallDto;
 import yeolJyeongKong.mall.domain.dto.MallPreviewDto;
@@ -38,7 +35,7 @@ public class MallController {
     @Operation(summary = "쇼핑몰 등록 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"쇼핑몰 등록 완료\"")))
     @GetMapping("/malls/add")
-    public ResponseEntity<?> save(@ModelAttribute MallDto mallDto) {
+    public ResponseEntity<?> save(@RequestBody MallDto mallDto) {
         mallService.save(mallDto);
         return new ResponseEntity<>("쇼핑몰 등록 완료", HttpStatus.OK);
     }

--- a/src/main/java/yeolJyeongKong/mall/controller/ProductController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/ProductController.java
@@ -16,10 +16,7 @@ import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import yeolJyeongKong.mall.config.PrincipalDetails;
 import yeolJyeongKong.mall.domain.dto.*;
-import yeolJyeongKong.mall.domain.entity.Category;
-import yeolJyeongKong.mall.domain.entity.Mall;
-import yeolJyeongKong.mall.domain.entity.Product;
-import yeolJyeongKong.mall.domain.entity.Size;
+import yeolJyeongKong.mall.domain.entity.*;
 import yeolJyeongKong.mall.service.*;
 
 import java.util.ArrayList;
@@ -44,7 +41,8 @@ public class ProductController {
     public ResponseEntity<?> save(@ModelAttribute ProductDetailDto productDto) {
         Category category = categoryService.findByName(productDto.getCategoryName());
         Mall mall = mallService.findByName(productDto.getMallName());
-        Product product = new Product(productDto, category, mall);
+        List<DescriptionImage> descriptionImages = productService.saveDescriptionImages(productDto.getDescriptionImages());
+        Product product = new Product(productDto, category, mall, descriptionImages);
         List<Size> sizes = new ArrayList<>();
 
         if(productDto.getType() == 0) {

--- a/src/main/java/yeolJyeongKong/mall/controller/ProductController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/ProductController.java
@@ -42,26 +42,21 @@ public class ProductController {
         Category category = categoryService.findByName(productDto.getCategoryName());
         Mall mall = mallService.findByName(productDto.getMallName());
         List<DescriptionImage> descriptionImages = productService.saveDescriptionImages(productDto.getDescriptionImages());
-        Product product = new Product(productDto, category, mall, descriptionImages);
+        Product product = productService.save(new Product(productDto, category, mall, descriptionImages));
         List<Size> sizes = new ArrayList<>();
 
         if(productDto.getType() == 0) {
             for(TopDto topDto : productDto.getTopSizes()) {
-                Size size = sizeService.saveTop(topDto);
-                size.setProduct(product);
+                Size size = sizeService.saveTop(topDto, product);
                 sizes.add(size);
             }
         } else {
             for(BottomDto bottomDto : productDto.getBottomSizes()) {
-                Size size = sizeService.saveBottom(bottomDto);
-                size.setProduct(product);
+                Size size = sizeService.saveBottom(bottomDto, product);
                 sizes.add(size);
             }
         }
 
-        product.setSizes(sizes);
-
-        productService.save(product);
         return new ResponseEntity<>("상품 등록 완료", HttpStatus.OK);
     }
 

--- a/src/main/java/yeolJyeongKong/mall/controller/ProductController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/ProductController.java
@@ -38,7 +38,7 @@ public class ProductController {
     @Operation(summary = "상품 등록 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"상품 등록 완료\"")))
     @PostMapping("/product/add")
-    public ResponseEntity<?> save(@ModelAttribute ProductDetailDto productDto) {
+    public ResponseEntity<?> save(@RequestBody ProductDetailDto productDto) {
         Category category = categoryService.findByName(productDto.getCategoryName());
         Mall mall = mallService.findByName(productDto.getMallName());
         List<DescriptionImage> descriptionImages = productService.saveDescriptionImages(productDto.getDescriptionImages());

--- a/src/main/java/yeolJyeongKong/mall/controller/SignController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/SignController.java
@@ -28,7 +28,7 @@ public class SignController {
     @Operation(summary = "로그인 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "{token}")))
     @PostMapping("/login")
-    public ResponseEntity<?> login(@ModelAttribute LoginDto loginDto) {
+    public ResponseEntity<?> login(@RequestBody LoginDto loginDto) {
         User user = userService.login(loginDto);
 
         if(user == null) {
@@ -40,7 +40,7 @@ public class SignController {
     @Operation(summary = "회원가입 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = SignUpDto.class)))
     @PostMapping("/signup")
-    public ResponseEntity<?> signUp(@ModelAttribute SignUpDto signUpDto) {
+    public ResponseEntity<?> signUp(@RequestBody SignUpDto signUpDto) {
         if (userService.usernameExist(signUpDto.getUsername())) {
             return new ResponseEntity<>("같은 이름이 존재합니다.", HttpStatus.BAD_REQUEST);
         }

--- a/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -51,7 +51,7 @@ public class UserController {
     @Operation(summary = "마이페이지 수정 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = UserDto.class)))
     @PostMapping("/user/edit")
-    public ResponseEntity<?> edit(@ModelAttribute UserDto userDto,
+    public ResponseEntity<?> edit(@RequestBody UserDto userDto,
                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
         userService.infoUpdate(userDto, principalDetails.getUser().getId());
         return new ResponseEntity<>(userDto, HttpStatus.OK);
@@ -85,7 +85,7 @@ public class UserController {
     @Operation(summary = "체형 정보 수정 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = MeasurementDto.class)))
     @PostMapping("/user/mysize/edit")
-    public ResponseEntity<?> measurementEdit(@ModelAttribute MeasurementDto measurementDto,
+    public ResponseEntity<?> measurementEdit(@RequestBody MeasurementDto measurementDto,
                                              @AuthenticationPrincipal PrincipalDetails principalDetails) {
         userService.measurementUpdate(measurementDto, principalDetails.getUser().getId());
         return new ResponseEntity<>(measurementDto, HttpStatus.OK);
@@ -131,7 +131,7 @@ public class UserController {
     @Operation(summary = "체형 측정 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = MeasurementDto.class))))
     @PostMapping("/user/recommendation/measurement")
-    public ResponseEntity<?> recommendMeasurement(@ModelAttribute ImageDto imageDto,
+    public ResponseEntity<?> recommendMeasurement(@RequestBody ImageDto imageDto,
                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
         String image = imageDto.getImage(); //request
         //TODO: API Gateway에 등록된 체형 측정 API에서 체형 측정 결과를 받아오는 로직 필요

--- a/src/main/java/yeolJyeongKong/mall/controller/UserController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/UserController.java
@@ -181,13 +181,18 @@ public class UserController {
             return productIds;
         }
 
-        RecentRecommendation recentRecommendation = productService.saveRecentRecommendation(userId);
-
         List<ProductPreviewDto> recentProducts = userService.recentProduct(userId); //request
-        //TODO: API Gateway에 등록된 추천 상품 API에서 데이터를 받아오는 로직 추가 필요
+        /**
+         * TODO: 추천 상품 API에서 데이터를 받아오는 로직 추가 필요
+         * - 해당 API에서 가져오는 상품 개수가 10개라고 가정
+         * - 각 recentRecommendation 객체는 userId 1개, productId 1개를 가지므로
+         *   10개의 recentRecommendation 객체 생성
+         */
         productIds = new ArrayList<>(); //response
 
-        productService.updateRecentRecommendation(recentRecommendation, productIds);
+        productIds.forEach(productId -> {
+            productService.saveRecentRecommendation(userId, productId);
+        });
 
         return productIds;
     }
@@ -233,13 +238,18 @@ public class UserController {
             return productIds;
         }
 
-        UserRecommendation userRecommendation = productService.saveUserRecommendation(userId);
-
         MeasurementDto measurement = userService.measurementInfo(userId); //request
-        //TODO: API Gateway에 등록된 비슷한 체형 고객 pick API에서 데이터를 받아오는 로직 추가 필요
+        /**
+         * TODO: 비슷한 체형 고객 pick API에서 데이터를 받아오는 로직 추가 필요
+         * - 해당 API에서 가져오는 상품 개수가 10개라고 가정
+         * - 각 userRecommenation 객체는 userId 1개, productId 1개를 가지므로
+         *   10개의 userRecommendation 객체 생성
+         */
         productIds = new ArrayList<>(); //response
 
-        productService.updateUserRecommendation(userRecommendation, productIds);
+        productIds.forEach(productId -> {
+            productService.saveUserRecommendation(userId, productId);
+        });
 
         return productIds;
     }

--- a/src/main/java/yeolJyeongKong/mall/domain/dto/ProductDetailDto.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/dto/ProductDetailDto.java
@@ -15,9 +15,9 @@ public class ProductDetailDto {
     private String gender;
     private Integer type;
     private String image;
-    private String descriptionImage;
     private String categoryName;
     private String mallName;
     private List<TopDto> topSizes;
     private List<BottomDto> bottomSizes;
+    private List<String> descriptionImages;
 }

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Bottom.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Bottom.java
@@ -1,6 +1,5 @@
 package yeolJyeongKong.mall.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -36,7 +35,6 @@ public class Bottom {
 
     private Double hipWidth;
 
-    @JsonIgnore
     @OneToOne(mappedBy = "bottom", fetch = LAZY)
     private Size size;
 

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Category.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Category.java
@@ -1,6 +1,5 @@
 package yeolJyeongKong.mall.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -24,7 +23,6 @@ public class Category {
     @NonNull @Length(max = 10)
     private String name;
 
-    @JsonIgnore
     @OneToMany(mappedBy = "category")
     private List<Product> products = new ArrayList<>();
 

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/DescriptionImage.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/DescriptionImage.java
@@ -1,0 +1,32 @@
+package yeolJyeongKong.mall.domain.entity;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
+
+import static jakarta.persistence.FetchType.LAZY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = PROTECTED)
+public class DescriptionImage {
+
+    @Id @GeneratedValue
+    @Column(name = "description_images_id")
+    private Long id;
+
+    @NonNull
+    private String url;
+
+    @JsonIgnore
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
+
+    public DescriptionImage(String url) {
+        this.url = url;
+    }
+}

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Mall.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Mall.java
@@ -22,7 +22,7 @@ public class Mall {
     @Column(name = "mall_id")
     private Long id;
 
-    @NonNull @Length(max = 15)
+    @NonNull @Length(max = 30)
     private String name;
 
     @NonNull

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
@@ -62,20 +62,17 @@ public class Product {
     @OneToMany(mappedBy = "product")
     private List<Size> sizes = new ArrayList<>();
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "recent_id")
-    private Recent recent;
+    @OneToMany(mappedBy = "product")
+    private List<Recent> recents = new ArrayList<>();
 
     @OneToMany(mappedBy = "product")
     private List<Favorite> favorites = new ArrayList<>();
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "user_recommendation_id")
-    private UserRecommendation userRecommendation;
+    @OneToMany(mappedBy = "product")
+    private List<UserRecommendation> userRecommendations = new ArrayList<>();
 
-    @ManyToOne(fetch = LAZY)
-    @JoinColumn(name = "recent_recommendation_id")
-    private RecentRecommendation recentRecommendation;
+    @OneToMany(mappedBy = "product")
+    private List<RecentRecommendation> recentRecommendations = new ArrayList<>();
 
     @OneToMany(mappedBy = "product")
     private List<DescriptionImage> descriptionImages = new ArrayList<>();
@@ -92,26 +89,6 @@ public class Product {
         this.category = category;
         this.mall = mall;
         this.descriptionImages = descriptionImages;
-    }
-
-    public void setSizes(List<Size> sizes) {
-        this.sizes = sizes;
-    }
-
-    public void setRecent(Recent recent) {
-        this.recent = recent;
-    }
-
-    public void deleteRecent() {
-        recent = null;
-    }
-
-    public void deleteUserRecommendation() {
-        userRecommendation = null;
-    }
-
-    public void deleteRecentRecommendation() {
-        recentRecommendation = null;
     }
 
     public void updateView() {

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
@@ -49,6 +49,7 @@ public class Product {
     @NonNull
     private Integer timeView;
 
+    @JsonIgnore
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "category_id")
     private Category category;

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
@@ -49,8 +49,6 @@ public class Product {
     @NonNull
     private Integer timeView;
 
-    private String descriptionImage;
-
     @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "category_id")
     private Category category;
@@ -78,17 +76,21 @@ public class Product {
     @JoinColumn(name = "recent_recommendation_id")
     private RecentRecommendation recentRecommendation;
 
-    public Product(ProductDetailDto productDto, Category category, Mall mall) {
+    @OneToMany(mappedBy = "product")
+    private List<DescriptionImage> descriptionImages = new ArrayList<>();
+
+    public Product(ProductDetailDto productDto, Category category,
+                   Mall mall, List<DescriptionImage> descriptionImages) {
         price = productDto.getPrice();
         name = productDto.getName();
         gender = productDto.getGender();
         type = productDto.getType();
         image = productDto.getImage();
-        descriptionImage = productDto.getDescriptionImage();
         view = 0;
         timeView = 0;
         this.category = category;
         this.mall = mall;
+        this.descriptionImages = descriptionImages;
     }
 
     public void setSizes(List<Size> sizes) {

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Product.java
@@ -26,7 +26,7 @@ public class Product {
     @NonNull
     private Integer price;
 
-    @NonNull @Length(max = 30)
+    @NonNull @Length(max = 50)
     private String name;
 
     @NonNull @Length(max = 1)

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Recent.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Recent.java
@@ -1,6 +1,10 @@
 package yeolJyeongKong.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +26,8 @@ public class Recent {
     @Column(name = "recent_id")
     private Long id;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @NonNull
     private LocalDateTime timestamp;
 

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Recent.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Recent.java
@@ -32,22 +32,18 @@ public class Recent {
     private LocalDateTime timestamp;
 
     @JsonIgnore
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "recent")
-    private List<Product> products = new ArrayList<>();
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
 
     public Recent(User user, Product product) {
         timestamp = LocalDateTime.now();
         this.user = user;
-        products.add(product);
-    }
-
-    public void update(Product product) {
-        product.setRecent(this);
-        products.add(product);
+        this.product = product;
     }
 }

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/RecentRecommendation.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/RecentRecommendation.java
@@ -21,19 +21,17 @@ public class RecentRecommendation {
     private Long id;
 
     @JsonIgnore
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
     @JsonIgnore
-    @OneToMany(mappedBy = "recentRecommendation")
-    private List<Product> products = new ArrayList<>();
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
 
-    public RecentRecommendation(User user) {
+    public RecentRecommendation(User user, Product product) {
         this.user = user;
-    }
-
-    public void update(List<Product> newProducts) {
-        products.addAll(newProducts);
+        this.product = product;
     }
 }

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
@@ -37,14 +37,16 @@ public class Size {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    public Size(TopDto topDto) {
-        this.name = topDto.getName();
-        this.top = new Top(topDto);
+    public Size(String name, Top top, Product product) {
+        this.name = name;
+        this.top = top;
+        this.product = product;
     }
 
-    public Size(BottomDto bottomDto) {
-        this.name = bottomDto.getName();
-        this.bottom = new Bottom(bottomDto);
+    public Size(String name, Bottom bottom, Product product) {
+        this.name = name;
+        this.bottom = bottom;
+        this.product = product;
     }
 
     public void setProduct(Product product) {

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
@@ -24,10 +24,12 @@ public class Size {
     @NonNull @Length(max = 10)
     private String name;
 
+    @JsonIgnore
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "top_id")
     private Top top;
 
+    @JsonIgnore
     @OneToOne(fetch = LAZY)
     @JoinColumn(name = "bottom_id")
     private Bottom bottom;

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Size.java
@@ -21,7 +21,7 @@ public class Size {
     @Column(name = "size_id")
     private Long id;
 
-    @NonNull @Length(max = 4)
+    @NonNull @Length(max = 10)
     private String name;
 
     @OneToOne(fetch = LAZY)

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/Top.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/Top.java
@@ -1,6 +1,5 @@
 package yeolJyeongKong.mall.domain.entity;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -30,7 +29,6 @@ public class Top {
     @NonNull
     private Double sleeve;
 
-    @JsonIgnore
     @OneToOne(mappedBy = "top", fetch = LAZY)
     private Size size;
 

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/User.java
@@ -1,5 +1,6 @@
 package yeolJyeongKong.mall.domain.entity;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -78,14 +79,16 @@ public class User {
     @OneToMany(mappedBy = "user")
     private List<Rank> ranks = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user", fetch = LAZY)
-    private Recent recent;
+    @OneToMany(mappedBy = "user", fetch = LAZY)
+    private List<Recent> recents = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user", fetch = LAZY)
-    private UserRecommendation userRecommendation;
+    @JsonIgnore
+    @OneToMany(mappedBy = "user", fetch = LAZY)
+    private List<UserRecommendation> userRecommendations = new ArrayList<>();
 
-    @OneToOne(mappedBy = "user", fetch = LAZY)
-    private RecentRecommendation recentRecommendation;
+    @JsonIgnore
+    @OneToMany(mappedBy = "user", fetch = LAZY)
+    private List<RecentRecommendation> recentRecommendations = new ArrayList<>();
 
     public User(SignUpDto signUpDto, String password, Measurement measurement) {
         email = signUpDto.getEmail();

--- a/src/main/java/yeolJyeongKong/mall/domain/entity/UserRecommendation.java
+++ b/src/main/java/yeolJyeongKong/mall/domain/entity/UserRecommendation.java
@@ -20,20 +20,16 @@ public class UserRecommendation {
     @Column(name = "user_recommendation_id")
     private Long id;
 
-    @JsonIgnore
-    @OneToOne(fetch = LAZY)
+    @ManyToOne(fetch = LAZY)
     @JoinColumn(name = "user_id")
     private User user;
 
-    @JsonIgnore
-    @OneToMany(mappedBy = "userRecommendation")
-    private List<Product> products = new ArrayList<>();
+    @ManyToOne(fetch = LAZY)
+    @JoinColumn(name = "product_id")
+    private Product product;
 
-    public UserRecommendation(User user) {
+    public UserRecommendation(User user, Product product) {
         this.user = user;
-    }
-
-    public void update(List<Product> newProducts) {
-        products.addAll(newProducts);
+        this.product = product;
     }
 }

--- a/src/main/java/yeolJyeongKong/mall/repository/DescriptionImageRepository.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/DescriptionImageRepository.java
@@ -1,0 +1,7 @@
+package yeolJyeongKong.mall.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import yeolJyeongKong.mall.domain.entity.DescriptionImage;
+
+public interface DescriptionImageRepository extends JpaRepository<DescriptionImage, Long> {
+}

--- a/src/main/java/yeolJyeongKong/mall/repository/RecentRecommendationRepository.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/RecentRecommendationRepository.java
@@ -1,10 +1,12 @@
 package yeolJyeongKong.mall.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yeolJyeongKong.mall.domain.entity.RecentRecommendation;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface RecentRecommendationRepository extends JpaRepository<RecentRecommendation, Long> {
-    Optional<RecentRecommendation> findByUserId(Long userId);
+    @EntityGraph(attributePaths = {"product"})
+    List<RecentRecommendation> findByUserId(Long userId);
 }

--- a/src/main/java/yeolJyeongKong/mall/repository/RecentRepository.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/RecentRepository.java
@@ -4,8 +4,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import yeolJyeongKong.mall.domain.entity.Recent;
 import yeolJyeongKong.mall.repository.querydsl.RecentRepositoryCustom;
 
-import java.util.Optional;
 
 public interface RecentRepository extends JpaRepository<Recent, Long>, RecentRepositoryCustom {
-    Optional<Recent> findByUserId(Long userId);
 }

--- a/src/main/java/yeolJyeongKong/mall/repository/UserRecommendationRepository.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/UserRecommendationRepository.java
@@ -1,10 +1,12 @@
 package yeolJyeongKong.mall.repository;
 
+import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import yeolJyeongKong.mall.domain.entity.UserRecommendation;
 
-import java.util.Optional;
+import java.util.List;
 
 public interface UserRecommendationRepository extends JpaRepository<UserRecommendation, Long> {
-    Optional<UserRecommendation> findByUserId(Long userId);
+    @EntityGraph(attributePaths = {"product"})
+    List<UserRecommendation> findByUserId(Long userId);
 }

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/FavoriteRepositoryImpl.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/FavoriteRepositoryImpl.java
@@ -63,7 +63,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count = queryFactory
+        Long nullableCount = queryFactory
                 .select(favorite.count())
                 .from(favorite)
                 .where(
@@ -71,6 +71,8 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
                         favorite.mall.isNull()
                 )
                 .fetchOne();
+
+        Long count = nullableCount != null ? nullableCount : 0L;
 
         return PageableExecutionUtils.getPage(content, pageable, () -> count);
     }

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/MallRepositoryImpl.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/MallRepositoryImpl.java
@@ -42,7 +42,7 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
 
     @Override
     public Long findFavoriteCount(Long favoriteId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(mall.count())
                 .from(mall)
                 .leftJoin(mall.favorites, favorite)
@@ -50,6 +50,7 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
                         favoriteIdEq(favoriteId)
                 )
                 .fetchOne();
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     public BooleanExpression favoriteIdEq(Long favoriteId) {

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -84,7 +84,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count = queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.category, category)
@@ -96,6 +96,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetchOne();
+
+        Long count = nullableCount != null ? nullableCount : 0L;
 
         return PageableExecutionUtils.getPage(content, pageable, () -> count);
     }
@@ -124,7 +126,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        Long count = queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.category, category)
@@ -136,12 +138,14 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .limit(pageable.getPageSize())
                 .fetchOne();
 
+        Long count = nullableCount != null ? nullableCount : 0L;
+
         return PageableExecutionUtils.getPage(content, pageable, () -> count);
     }
 
     @Override
     public Long productCountWithCategory(Long categoryId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.category, category)
@@ -149,11 +153,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         categoryIdEq(categoryId)
                 )
                 .fetchOne();
+
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     @Override
     public Long productCountWithCategoryOfMall(String mallName, Long categoryId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.category, category)
@@ -163,11 +169,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         mallNameEq(mallName)
                 )
                 .fetchOne();
+
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     @Override
     public TopProductDto topProductDetail(Long productId) {
-        Long favoriteCount = queryFactory
+        Long nullableFavoriteCount = queryFactory
                 .select(favorite.count())
                 .from(favorite)
                 .leftJoin(favorite.product, product)
@@ -175,6 +183,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         productIdEq(productId)
                 )
                 .fetchOne();
+
+        Long favoriteCount = nullableFavoriteCount != null ? nullableFavoriteCount : 0L;
 
         Product productInfo = queryFactory
                 .selectFrom(product)
@@ -221,7 +231,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     @Override
     public BottomProductDto bottomProductDetail(Long productId) {
-        Long favoriteCount = queryFactory
+        Long nullableFavoriteCount = queryFactory
                 .select(favorite.count())
                 .from(favorite)
                 .leftJoin(favorite.product, product)
@@ -229,6 +239,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         productIdEq(productId)
                 )
                 .fetchOne();
+
+        Long favoriteCount = nullableFavoriteCount != null ? nullableFavoriteCount : 0L;
 
         Tuple tuple = queryFactory
                 .select(product.count(), user.gender, user.ageRange)
@@ -292,7 +304,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     @Override
     public Long findFavoriteCount(Long favoriteId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.favorites, favorite)
@@ -300,11 +312,12 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         favoriteIdEq(favoriteId)
                 )
                 .fetchOne();
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     @Override
     public Long findRecentCount(Long recentId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.recent, recent)
@@ -312,11 +325,12 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         recentIdEq(recentId)
                 )
                 .fetchOne();
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     @Override
     public Long findRecentRecommendation(Long recentRecommendationId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.recentRecommendation, recentRecommendation)
@@ -324,11 +338,12 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         recentRecommendationIdEq(recentRecommendationId)
                 )
                 .fetchOne();
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     @Override
     public Long findUserRecommendation(Long userRecommendationId) {
-        return queryFactory
+        Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
                 .leftJoin(product.userRecommendation, userRecommendation)
@@ -336,6 +351,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         userRecommendationIdEq(userRecommendationId)
                 )
                 .fetchOne();
+        return nullableCount != null ? nullableCount : 0L;
     }
 
     public BooleanExpression categoryIdEq(Long categoryId) {

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -320,7 +320,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
-                .leftJoin(product.recent, recent)
+                .leftJoin(product.recents, recent)
                 .where(
                         recentIdEq(recentId)
                 )
@@ -333,7 +333,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
-                .leftJoin(product.recentRecommendation, recentRecommendation)
+                .leftJoin(product.recentRecommendations, recentRecommendation)
                 .where(
                         recentRecommendationIdEq(recentRecommendationId)
                 )
@@ -346,7 +346,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
         Long nullableCount = queryFactory
                 .select(product.count())
                 .from(product)
-                .leftJoin(product.userRecommendation, userRecommendation)
+                .leftJoin(product.userRecommendations, userRecommendation)
                 .where(
                         userRecommendationIdEq(userRecommendationId)
                 )

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/RecentRepositoryCustom.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/RecentRepositoryCustom.java
@@ -1,9 +1,11 @@
 package yeolJyeongKong.mall.repository.querydsl;
 
 import yeolJyeongKong.mall.domain.dto.ProductPreviewDto;
+import yeolJyeongKong.mall.domain.entity.Recent;
 
 import java.util.List;
 
 public interface RecentRepositoryCustom {
+    List<Recent> findByUserId(Long userId);
     List<ProductPreviewDto> recentProduct(Long userId);
 }

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/RecentRepositoryImpl.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/RecentRepositoryImpl.java
@@ -6,6 +6,7 @@ import jakarta.persistence.EntityManager;
 import yeolJyeongKong.mall.domain.dto.ProductPreviewDto;
 import yeolJyeongKong.mall.domain.dto.QProductPreviewDto;
 import yeolJyeongKong.mall.domain.entity.QMall;
+import yeolJyeongKong.mall.domain.entity.Recent;
 
 import java.util.List;
 
@@ -20,6 +21,18 @@ public class RecentRepositoryImpl implements RecentRepositoryCustom {
 
     public RecentRepositoryImpl(EntityManager em) {
         this.queryFactory = new JPAQueryFactory(em);
+    }
+
+    @Override
+    public List<Recent> findByUserId(Long userId) {
+        return queryFactory
+                .selectFrom(recent)
+                .leftJoin(recent.user, user)
+                .leftJoin(recent.product, product)
+                .where(
+                        userIdEq(userId)
+                )
+                .fetch();
     }
 
     /**
@@ -39,7 +52,7 @@ public class RecentRepositoryImpl implements RecentRepositoryCustom {
                 ))
                 .from(recent)
                 .leftJoin(recent.user, user)
-                .leftJoin(recent.products, product)
+                .leftJoin(recent.product, product)
                 .leftJoin(product.mall, mall)
                 .where(
                         userIdEq(userId)

--- a/src/main/java/yeolJyeongKong/mall/service/ProductService.java
+++ b/src/main/java/yeolJyeongKong/mall/service/ProductService.java
@@ -107,47 +107,33 @@ public class ProductService {
     }
 
     @Transactional
-    public RecentRecommendation saveRecentRecommendation(Long userId) {
+    public RecentRecommendation saveRecentRecommendation(Long userId, Long productId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoResultException("user doesn't exist"));
-
-        RecentRecommendation recentRecommendation = new RecentRecommendation(user);
-        return recentRecommendationRepository.save(recentRecommendation);
+        Product product = findById(productId);
+        return recentRecommendationRepository.save(new RecentRecommendation(user, product));
     }
 
     @Transactional
-    public void updateRecentRecommendation(RecentRecommendation recentRecommendation, List<Long> productIds) {
-        List<Product> products = productRepository.findByIds(productIds);
-        recentRecommendation.update(products);
-    }
-
-    @Transactional
-    public UserRecommendation saveUserRecommendation(Long userId) {
+    public UserRecommendation saveUserRecommendation(Long userId, Long productId) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NoResultException("user doesn't exist"));
-
-        UserRecommendation userRecommendation = new UserRecommendation(user);
-        return userRecommendationRepository.save(userRecommendation);
+        Product product = findById(productId);
+        return userRecommendationRepository.save(new UserRecommendation(user, product));
     }
 
-    @Transactional
-    public void updateUserRecommendation(UserRecommendation userRecommendation, List<Long> productIds) {
-        List<Product> products = productRepository.findByIds(productIds);
-        userRecommendation.update(products);
-    }
-
-    @Cacheable(value = "ProductWithRecentRecommendation", key = "#userId")
     public List<Product> productWithRecentRecommendation(Long userId) {
-        return recentRecommendationRepository.findByUserId(userId)
-                .map(RecentRecommendation::getProducts)
-                .orElse(new ArrayList<>());
+        List<Product> result = new ArrayList<>();
+        recentRecommendationRepository.findByUserId(userId).forEach(recentRecommendation ->
+                result.add(recentRecommendation.getProduct()));
+        return result;
     }
 
-    @Cacheable(value = "ProductWithUserRecommendation", key = "#userId")
     public List<Product> productWithUserRecommendation(Long userId) {
-        return userRecommendationRepository.findByUserId(userId)
-                .map(UserRecommendation::getProducts)
-                .orElse(new ArrayList<>());
+        List<Product> result = new ArrayList<>();
+        userRecommendationRepository.findByUserId(userId).forEach(userRecommendation ->
+                result.add(userRecommendation.getProduct()));
+        return result;
     }
 
     @Transactional

--- a/src/main/java/yeolJyeongKong/mall/service/ProductService.java
+++ b/src/main/java/yeolJyeongKong/mall/service/ProductService.java
@@ -24,6 +24,7 @@ public class ProductService {
     private final MallRepository mallRepository;
     private final RecentRecommendationRepository recentRecommendationRepository;
     private final UserRecommendationRepository userRecommendationRepository;
+    private final DescriptionImageRepository descriptionImageRepository;
 
     @Transactional
     public Product save(Product product) {
@@ -147,5 +148,15 @@ public class ProductService {
         return userRecommendationRepository.findByUserId(userId)
                 .map(UserRecommendation::getProducts)
                 .orElse(new ArrayList<>());
+    }
+
+    @Transactional
+    public List<DescriptionImage> saveDescriptionImages(List<String> descriptionImages) {
+        List<DescriptionImage> result = new ArrayList<>();
+        descriptionImages.forEach(descriptionImageUrl -> {
+            DescriptionImage descriptionImage = new DescriptionImage(descriptionImageUrl);
+            result.add(descriptionImageRepository.save(descriptionImage));
+        });
+        return result;
     }
 }

--- a/src/main/java/yeolJyeongKong/mall/service/SizeService.java
+++ b/src/main/java/yeolJyeongKong/mall/service/SizeService.java
@@ -4,26 +4,30 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import yeolJyeongKong.mall.domain.dto.BottomDto;
 import yeolJyeongKong.mall.domain.dto.TopDto;
+import yeolJyeongKong.mall.domain.entity.Bottom;
 import yeolJyeongKong.mall.domain.entity.Product;
 import yeolJyeongKong.mall.domain.entity.Size;
+import yeolJyeongKong.mall.domain.entity.Top;
+import yeolJyeongKong.mall.repository.BottomRepository;
 import yeolJyeongKong.mall.repository.SizeRepository;
+import yeolJyeongKong.mall.repository.TopRepository;
 
 @Service
 @RequiredArgsConstructor
 public class SizeService {
 
     private final SizeRepository sizeRepository;
+    private final TopRepository topRepository;
+    private final BottomRepository bottomRepository;
 
-    public Size saveTop(TopDto topDto) {
-        Size size = new Size(topDto);
-        sizeRepository.save(size);
-        return size;
+    public Size saveTop(TopDto topDto, Product product) {
+        Top top = topRepository.save(new Top(topDto));
+        return sizeRepository.save(new Size(topDto.getName(), top, product));
     }
 
-    public Size saveBottom(BottomDto bottomDto) {
-        Size size = new Size(bottomDto);
-        sizeRepository.save(new Size(bottomDto));
-        return size;
+    public Size saveBottom(BottomDto bottomDto, Product product) {
+        Bottom bottom = bottomRepository.save(new Bottom(bottomDto));
+        return sizeRepository.save(new Size(bottomDto.getName(), bottom, product));
     }
 
     public void setProduct(Size size, Product product) {

--- a/src/main/java/yeolJyeongKong/mall/service/SizeService.java
+++ b/src/main/java/yeolJyeongKong/mall/service/SizeService.java
@@ -1,5 +1,6 @@
 package yeolJyeongKong.mall.service;
 
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import yeolJyeongKong.mall.domain.dto.BottomDto;
@@ -20,16 +21,19 @@ public class SizeService {
     private final TopRepository topRepository;
     private final BottomRepository bottomRepository;
 
+    @Transactional
     public Size saveTop(TopDto topDto, Product product) {
         Top top = topRepository.save(new Top(topDto));
         return sizeRepository.save(new Size(topDto.getName(), top, product));
     }
 
+    @Transactional
     public Size saveBottom(BottomDto bottomDto, Product product) {
         Bottom bottom = bottomRepository.save(new Bottom(bottomDto));
         return sizeRepository.save(new Size(bottomDto.getName(), bottom, product));
     }
 
+    @Transactional
     public void setProduct(Size size, Product product) {
         size.setProduct(product);
     }

--- a/src/test/java/yeolJyeongKong/mall/service/FavoriteServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/FavoriteServiceTest.java
@@ -72,21 +72,24 @@ class FavoriteServiceTest {
         Mall mall = mallService.save(new MallDto("testMall", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
         User user = userService.save(new SignUpDto("test", "password", "test@test.com", "M", 1, 2, 3));
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
+
         Product product = productService.save(new Product(
                 new ProductDetailDto(10000, "tp1", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                category, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                category, mall, descImgs));
         Product product2 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp2", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                category, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                category, mall, descImgs));
         Product product3 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp3", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                category, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                category, mall, descImgs));
 
         favoriteService.saveFavoriteProduct(user.getId(), product.getId());
         favoriteService.saveFavoriteProduct(user.getId(), product2.getId());

--- a/src/test/java/yeolJyeongKong/mall/service/MallServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/MallServiceTest.java
@@ -8,10 +8,12 @@ import org.springframework.boot.test.context.SpringBootTest;
 import yeolJyeongKong.mall.domain.dto.MallDto;
 import yeolJyeongKong.mall.domain.dto.ProductDetailDto;
 import yeolJyeongKong.mall.domain.entity.Category;
+import yeolJyeongKong.mall.domain.entity.DescriptionImage;
 import yeolJyeongKong.mall.domain.entity.Mall;
 import yeolJyeongKong.mall.domain.entity.Product;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -42,11 +44,13 @@ class MallServiceTest {
         checkMall(mall3, findMall3);
 
         Category category = categoryService.save("top");
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
         Product product = productService.save(new Product(
                 new ProductDetailDto(10000, "tp1", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                category, mall1));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                category, mall1, descImgs));
         mallService.addProduct("testMall1", product.getId());
         mallService.findProducts("testMall1").forEach(productDto -> {
             assertThat(productDto.getProductId()).isEqualTo(product.getId());

--- a/src/test/java/yeolJyeongKong/mall/service/ProductServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/ProductServiceTest.java
@@ -31,6 +31,8 @@ class ProductServiceTest {
     private Category topCategory;
     private Category bottomCategory;
     private Mall mall;
+    private List<String> descImgsStr;
+    private List<DescriptionImage> descImgs;
     private Product savedProduct;
     private Product product2;
     private Product product3;
@@ -45,31 +47,33 @@ class ProductServiceTest {
         mall = mallService.save(new MallDto("testMall", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
         user = userService.save(new SignUpDto("test", "password", "test@test.com", "M", 1, 2, 3));
+        descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
         savedProduct = productService.save(new Product(
                 new ProductDetailDto(10000, "tp1", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product2 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp2", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product3 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp3", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product4 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp4", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product5 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp5", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top", "testMall",
+                        null, null, descImgsStr),
+                topCategory, mall, descImgs));
     }
 
     @Test
@@ -104,34 +108,34 @@ class ProductServiceTest {
     void multipleProductCountWithCategory() {
         Product topProduct2 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp2", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         Product topProduct3 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp3", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         Product bottomProduct1 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp1", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall", null, null),
-                bottomCategory, mall));
+                        "image.jpg", "bottom",
+                        "testMall", null, null, descImgsStr),
+                bottomCategory, mall, descImgs));
         Product bottomProduct2 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp2", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall", null, null),
-                bottomCategory, mall));
+                        "image.jpg", "bottom",
+                        "testMall", null, null, descImgsStr),
+                bottomCategory, mall, descImgs));
         Product bottomProduct3 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp3", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall", null, null),
-                bottomCategory, mall));
+                        "image.jpg", "bottom",
+                        "testMall", null, null, descImgsStr),
+                bottomCategory, mall, descImgs));
         Product bottomProduct4 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp4", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall", null, null),
-                bottomCategory, mall));
+                        "image.jpg", "bottom",
+                        "testMall", null, null, descImgsStr),
+                bottomCategory, mall, descImgs));
 
         List<ProductCategoryDto> findProductCountsOnCategory = productService.multipleProductCountWithCategory();
         assertThat(findProductCountsOnCategory.get(0).getCount()).isEqualTo(7);
@@ -142,37 +146,37 @@ class ProductServiceTest {
     void productCountWithCategoryOfMall() {
         Product topProduct2 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp2", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         Product topProduct3 = productService.save(new Product(
                 new ProductDetailDto(10000, "tp3", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
 
         Mall mall2 = mallService.save(new MallDto("testMall2", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
         Product bottomProduct1 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp1", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall2", null, null),
-                bottomCategory, mall2));
+                        "image.jpg", "bottom",
+                        "testMall2", null, null, descImgsStr),
+                bottomCategory, mall2, descImgs));
         Product bottomProduct2 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp2", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall2", null, null),
-                bottomCategory, mall2));
+                        "image.jpg", "bottom",
+                        "testMall2", null, null, descImgsStr),
+                bottomCategory, mall2, descImgs));
         Product bottomProduct3 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp3", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall2", null, null),
-                bottomCategory, mall2));
+                        "image.jpg", "bottom",
+                        "testMall2", null, null, descImgsStr),
+                bottomCategory, mall2, descImgs));
         Product bottomProduct4 = productService.save(new Product(
                 new ProductDetailDto(10000, "bp4", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall2", null, null),
-                bottomCategory, mall2));
+                        "image.jpg", "bottom",
+                        "testMall2", null, null, descImgsStr),
+                bottomCategory, mall2, descImgs));
 
         List<ProductCategoryDto> findProductCountsOnCategoryOfMall = productService.productCountWithCategoryOfMall(mall.getId());
         assertThat(findProductCountsOnCategoryOfMall.get(0).getCount()).isEqualTo(7);
@@ -231,9 +235,9 @@ class ProductServiceTest {
     void bottomProductDetail() {
         Product bottomProduct = productService.save(new Product(
                 new ProductDetailDto(10000, "bp1", "M", 0,
-                        "image.jpg", "desc", "bottom",
-                        "testMall", null, null),
-                bottomCategory, mall));
+                        "image.jpg", "bottom",
+                        "testMall", null, null, descImgsStr),
+                bottomCategory, mall, descImgs));
 
         BottomProductDto bottomProductDto = productService.bottomProductDetail(bottomProduct.getId());
         assertThat(bottomProductDto.getProductImage()).isEqualTo(bottomProduct.getImage());
@@ -309,7 +313,9 @@ class ProductServiceTest {
         assertThat(savedProduct.getView()).isEqualTo(findProduct.getView());
         assertThat(savedProduct.getTimeView()).isEqualTo(findProduct.getTimeView());
         assertThat(savedProduct.getType()).isEqualTo(findProduct.getType());
-        assertThat(savedProduct.getDescriptionImage()).isEqualTo(findProduct.getDescriptionImage());
+        savedProduct.getDescriptionImages().forEach(descImg -> {
+            assertThat(findProduct.getDescriptionImages().contains(descImg)).isTrue();
+        });
     }
 
     private static void compareProduct(Product savedProduct, ProductPreviewDto productPreviewDto) {

--- a/src/test/java/yeolJyeongKong/mall/service/ProductServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/ProductServiceTest.java
@@ -262,16 +262,11 @@ class ProductServiceTest {
 
     @Test
     void recentRecommendationTest() {
-        RecentRecommendation recentRecommendation = productService.saveRecentRecommendation(user.getId());
-        List<Long> productIds = new ArrayList<>(){{
-            add(savedProduct.getId());
-            add(product2.getId());
-            add(product3.getId());
-            add(product4.getId());
-            add(product5.getId());
-        }};
-
-        productService.updateRecentRecommendation(recentRecommendation, productIds);
+        productService.saveRecentRecommendation(user.getId(), savedProduct.getId());
+        productService.saveRecentRecommendation(user.getId(), product2.getId());
+        productService.saveRecentRecommendation(user.getId(), product3.getId());
+        productService.saveRecentRecommendation(user.getId(), product4.getId());
+        productService.saveRecentRecommendation(user.getId(), product5.getId());
 
         List<Product> products = productService.productWithRecentRecommendation(user.getId());
         assertThat(products.size()).isEqualTo(5);
@@ -284,16 +279,11 @@ class ProductServiceTest {
 
     @Test
     void userRecommendationTest() {
-        UserRecommendation userRecommendation = productService.saveUserRecommendation(user.getId());
-        List<Long> productIds = new ArrayList<>(){{
-            add(savedProduct.getId());
-            add(product2.getId());
-            add(product3.getId());
-            add(product4.getId());
-            add(product5.getId());
-        }};
-
-        productService.updateUserRecommendation(userRecommendation, productIds);
+        productService.saveUserRecommendation(user.getId(), savedProduct.getId());
+        productService.saveUserRecommendation(user.getId(), product2.getId());
+        productService.saveUserRecommendation(user.getId(), product3.getId());
+        productService.saveUserRecommendation(user.getId(), product4.getId());
+        productService.saveUserRecommendation(user.getId(), product5.getId());
 
         List<Product> products = productService.productWithUserRecommendation(user.getId());
         assertThat(products.size()).isEqualTo(5);

--- a/src/test/java/yeolJyeongKong/mall/service/RankServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/RankServiceTest.java
@@ -44,27 +44,29 @@ class RankServiceTest {
                 "image.jpg", "desc", new ArrayList<>()));
         mall2 = mallService.save(new MallDto("testMall2", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
-        savedProduct = productService.save(new Product(
-                new ProductDetailDto(10000, "tp1", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
         user = userService.save(new SignUpDto("test", "password", "test@test.com", "M", 1, 2, 3));
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
+        savedProduct = productService.save(new Product(
+                new ProductDetailDto(10000, "A 티셔츠", "M", 0,
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product2 = productService.save(new Product(
-                new ProductDetailDto(10000, "tp2", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                new ProductDetailDto(10000, "A 셔츠", "M", 0,
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product3 = productService.save(new Product(
-                new ProductDetailDto(10000, "tp3", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                new ProductDetailDto(10000, "B 티셔츠", "M", 0,
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product4 = productService.save(new Product(
-                new ProductDetailDto(10000, "tp4", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall2", null, null),
-                topCategory, mall2));
+                new ProductDetailDto(10000, "ABC 스웨터", "M", 0,
+                        "image.jpg", "top",
+                        "testMall2", null, null, descImgsStr),
+                topCategory, mall2, descImgs));
     }
 
     @Test

--- a/src/test/java/yeolJyeongKong/mall/service/SearchServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/SearchServiceTest.java
@@ -11,10 +11,7 @@ import yeolJyeongKong.mall.domain.dto.MallDto;
 import yeolJyeongKong.mall.domain.dto.ProductDetailDto;
 import yeolJyeongKong.mall.domain.dto.ProductPreviewDto;
 import yeolJyeongKong.mall.domain.dto.SignUpDto;
-import yeolJyeongKong.mall.domain.entity.Category;
-import yeolJyeongKong.mall.domain.entity.Mall;
-import yeolJyeongKong.mall.domain.entity.Product;
-import yeolJyeongKong.mall.domain.entity.User;
+import yeolJyeongKong.mall.domain.entity.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +38,8 @@ class SearchServiceTest {
     private Category topCategory;
     private Mall mall;
     private Mall mall2;
+    private List<String> descImgsStr;
+    private List<DescriptionImage> descImgs;
     private Product savedProduct;
     private Product product2;
     private Product product3;
@@ -55,26 +54,28 @@ class SearchServiceTest {
         mall2 = mallService.save(new MallDto("testMall2", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
         user = userService.save(new SignUpDto("test", "password", "test@test.com", "M", 1, 2, 3));
+        descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
         savedProduct = productService.save(new Product(
                 new ProductDetailDto(10000, "A 티셔츠", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product2 = productService.save(new Product(
                 new ProductDetailDto(10000, "A 셔츠", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product3 = productService.save(new Product(
                 new ProductDetailDto(10000, "B 티셔츠", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
         product4 = productService.save(new Product(
                 new ProductDetailDto(10000, "ABC 스웨터", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall2", null, null),
-                topCategory, mall2));
+                        "image.jpg", "top",
+                        "testMall2", null, null, descImgsStr),
+                topCategory, mall2, descImgs));
     }
 
     @Test

--- a/src/test/java/yeolJyeongKong/mall/service/SizeServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/SizeServiceTest.java
@@ -4,10 +4,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
-import yeolJyeongKong.mall.domain.dto.BottomDto;
-import yeolJyeongKong.mall.domain.dto.MallDto;
-import yeolJyeongKong.mall.domain.dto.ProductDetailDto;
-import yeolJyeongKong.mall.domain.dto.TopDto;
+import yeolJyeongKong.mall.domain.dto.*;
 import yeolJyeongKong.mall.domain.entity.*;
 
 import java.util.ArrayList;
@@ -30,12 +27,24 @@ class SizeServiceTest {
 
     @Test
     void saveTop() {
+        Category category = categoryService.save("top");
+        Mall mall = mallService.save(new MallDto("testMall", "testMall.com",
+                "image.jpg", "desc", new ArrayList<>()));
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
+        Product product = productService.save(new Product(
+                new ProductDetailDto(10000, "A 티셔츠", "M", 0,
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                category, mall, descImgs));
+
         TopDto topDto1 = new TopDto("S", 68.0, 50.0, 53.0, 24.0);
         TopDto topDto2 = new TopDto("M", 69.5, 51.5, 55.5, 25.0);
         TopDto topDto3 = new TopDto("L", 71.0, 53.0, 58.0, 26.0);
-        Size topSize1 = sizeService.saveTop(topDto1);
-        Size topSize2 = sizeService.saveTop(topDto2);
-        Size topSize3 = sizeService.saveTop(topDto3);
+
+        Size topSize1 = sizeService.saveTop(topDto1, product);
+        Size topSize2 = sizeService.saveTop(topDto2, product);
+        Size topSize3 = sizeService.saveTop(topDto3, product);
 
         compareTopSize(topDto1, topSize1);
         compareTopSize(topDto2, topSize2);
@@ -44,12 +53,24 @@ class SizeServiceTest {
 
     @Test
     void saveBottom() {
+        Category category = categoryService.save("top");
+        Mall mall = mallService.save(new MallDto("testMall", "testMall.com",
+                "image.jpg", "desc", new ArrayList<>()));
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
+        Product product = productService.save(new Product(
+                new ProductDetailDto(10000, "A 티셔츠", "M", 0,
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                category, mall, descImgs));
+
         BottomDto bottomDto1 = new BottomDto("S", 104.0, 37.5, 51.5, 33.8, 28.0, 26.0);
         BottomDto bottomDto2 = new BottomDto("M", 105.0, 40.0, 54.0, 35.0, 29.0, 27.0);
         BottomDto bottomDto3 = new BottomDto("L", 106.0, 42.5, 56.5, 36.2, 30.0, 28.0);
-        Size bottomSize1 = sizeService.saveBottom(bottomDto1);
-        Size bottomSize2 = sizeService.saveBottom(bottomDto2);
-        Size bottomSize3 = sizeService.saveBottom(bottomDto3);
+
+        Size bottomSize1 = sizeService.saveBottom(bottomDto1, product);
+        Size bottomSize2 = sizeService.saveBottom(bottomDto2, product);
+        Size bottomSize3 = sizeService.saveBottom(bottomDto3, product);
 
         compareBottomSize(bottomDto1, bottomSize1);
         compareBottomSize(bottomDto2, bottomSize2);
@@ -70,7 +91,7 @@ class SizeServiceTest {
                 topCategory, mall, descImgs));
 
         BottomDto bottomDto = new BottomDto("S", 104.0, 37.5, 51.5, 33.8, 28.0, 26.0);
-        Size bottomSize = sizeService.saveBottom(bottomDto);
+        Size bottomSize = sizeService.saveBottom(bottomDto, product);
 
         sizeService.setProduct(bottomSize, product);
 

--- a/src/test/java/yeolJyeongKong/mall/service/SizeServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/SizeServiceTest.java
@@ -11,6 +11,7 @@ import yeolJyeongKong.mall.domain.dto.TopDto;
 import yeolJyeongKong.mall.domain.entity.*;
 
 import java.util.ArrayList;
+import java.util.List;
 
 import static org.junit.jupiter.api.Assertions.*;
 
@@ -60,11 +61,13 @@ class SizeServiceTest {
         Category topCategory = categoryService.save("top");
         Mall mall = mallService.save(new MallDto("testMall", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
         Product product = productService.save(new Product(
                 new ProductDetailDto(10000, "tp1", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                topCategory, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                topCategory, mall, descImgs));
 
         BottomDto bottomDto = new BottomDto("S", 104.0, 37.5, 51.5, 33.8, 28.0, 26.0);
         Size bottomSize = sizeService.saveBottom(bottomDto);

--- a/src/test/java/yeolJyeongKong/mall/service/UserServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/UserServiceTest.java
@@ -61,11 +61,13 @@ class UserServiceTest {
         category = categoryService.save("top");
         mall = mallService.save(new MallDto("testMall", "testMall.com",
                 "image.jpg", "desc", new ArrayList<>()));
+        List<String> descImgsStr = new ArrayList<>(){{ add("descImage.jpg"); }};
+        List<DescriptionImage> descImgs = new ArrayList<>(){{ add(new DescriptionImage(descImgsStr.get(0))); }};
         product = productService.save(new Product(
                 new ProductDetailDto(10000, "tp1", "M", 0,
-                        "image.jpg", "desc", "top",
-                        "testMall", null, null),
-                category, mall));
+                        "image.jpg", "top",
+                        "testMall", null, null, descImgsStr),
+                category, mall, descImgs));
     }
 
     @Test

--- a/src/test/java/yeolJyeongKong/mall/service/UserServiceTest.java
+++ b/src/test/java/yeolJyeongKong/mall/service/UserServiceTest.java
@@ -170,14 +170,8 @@ class UserServiceTest {
         Rank rank = rankService.save(user.getId(), mall.getId());
         Recent recent = userService.saveRecentProduct(user.getId(), product.getId());
 
-        List<Long> productIds = new ArrayList<>(){{
-            add(product.getId());
-        }};
-        RecentRecommendation recentRecommendation = productService.saveRecentRecommendation(user.getId());
-        productService.updateRecentRecommendation(recentRecommendation, productIds);
-
-        UserRecommendation userRecommendation = productService.saveUserRecommendation(user.getId());
-        productService.updateUserRecommendation(userRecommendation, productIds);
+        RecentRecommendation recentRecommendation = productService.saveRecentRecommendation(user.getId(), product.getId());
+        UserRecommendation userRecommendation = productService.saveUserRecommendation(user.getId(), product.getId());
 
         userService.delete(user.getId());
 


### PR DESCRIPTION
## 전체 API 테스트
로그인/회원가입, 비밀번호 찾기 관련 API를 제외한 모든 API에 대해 정상적으로 동작하는지 체크했습니다.
테스트 도중에 발생한 문제를 해결했거나 잘못된 구현한 부분을 수정하는 내용 위주로 정리했습니다.

### 상품 상세 이미지 개수 확장
상품 상세 정보에 들어가는 이미지를 1장으로 설정했으나 여러 상품을 찾아보니 **여러 장**으로 구성돼있는 상세 정보를 확인할 수 있었고 우리 서비스는 타 쇼핑몰에 있는 상품 정보 기반으로 업데이트할 계획이므로 여러 장을 게시할 수 있도록 `DescriptionImage` 엔티티를 만들어 `Product`와 연관관계를 `@OneToMany`로 설정했습니다. 이에 대한 연관 로직 수정 및 테스트까지 완료했습니다.
```java
//DescriptionImage 엔티티 정의
public class DescriptionImage {
    private Long id;
    private String url;

    @ManyToOne
    private Product product;
}

//Product 엔티티
public class Product {
    ...
    @OneToMany(mappedBy = "product")
    private List<DescriptionImage> descriptionImages = new ArrayList<>();
}
```
- [feat: 상품 상세 이미지 업로드 개수 확장](https://github.com/YeolJyeongKong/fittering-BE/commit/d00d9b824cf9ba8a48e0a7aa1d41bdd54dc02445)

### 필드 길이 제한 수정
실제 상품으로 데이터를 등록하면서 테스트하던 중 `Size`, `Product`, `Mall` 이름 길이 제한이 작게 설정돼있어 재설정했습니다.
- `Size.name` : 4 -> **10**
- `Product.name` : 30 -> **50**
- `Mall.name` : 15 -> **30**
```
List of constraint violations:[
	ConstraintViolationImpl{interpolatedMessage='길이가 0에서 4 사이여야 합니다', propertyPath=name, rootBeanClass=class yeolJyeongKong.mall.domain.entity.Size, messageTemplate='{org.hibernate.validator.constraints.Length.message}'}
]

List of constraint violations:[
	ConstraintViolationImpl{interpolatedMessage='길이가 0에서 30 사이여야 합니다', propertyPath=name, rootBeanClass=class yeolJyeongKong.mall.domain.entity.Product, messageTemplate='{org.hibernate.validator.constraints.Length.message}'}
]

List of constraint violations:[
	ConstraintViolationImpl{interpolatedMessage='길이가 0에서 15 사이여야 합니다', propertyPath=name, rootBeanClass=class yeolJyeongKong.mall.domain.entity.Mall, messageTemplate='{org.hibernate.validator.constraints.Length.message}'}
]
```
- [fix: 필드 길이 제한 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/d97aba0ab785e6944bc84462971039d79f7f46d3)

### PK 없는 객체 참조하는 문제 수정
`Product` 저장 API를 테스트하던 중 `Product`와 연관된 엔티티 객체 `Size`를 먼저 생성해주는 과정에서 아직 영속성 컨텍스트에 의해 관리되지 않는 `Product` 즉, PK가 없는 객체를 연관관계로 설정해주는 바람에 에러가 발생했습니다.
```
org.hibernate.TransientPropertyValueException: object references an unsaved transient instance - save the transient instance before flushing : yeolJyeongKong.mall.domain.entity.Size.product -> yeolJyeongKong.mall.domain.entity.Product
...
```
```java
Product product = new Product(productDto, category, mall, descriptionImages); //PK 없는 Product 객체
List<Size> sizes = new ArrayList<>();

if(productDto.getType() == 0) {
    for(TopDto topDto : productDto.getTopSizes()) {
        Size size = sizeService.saveTop(topDto);
        size.setProduct(product); //에러 발생
        sizes.add(size);
    }
}
```

생성한 `Product` 영속성 컨텍스트에 관리되는 객체로 만들어주기 위해 `ProductRepository`를 거치도록 해주고 `Size` 생성자에 해당 `Product`를 파라미터로 넘겨줘 내부에서 연관관계를 설정해주도록 수정했습니다.
```java
Product product = productService.save(new Product(productDto, category, mall, descriptionImages)); //수정
List<Size> sizes = new ArrayList<>();

if(productDto.getType() == 0) {
    for(TopDto topDto : productDto.getTopSizes()) {
        Size size = sizeService.saveTop(topDto, product); //Product - Size 연관관계 설정
        sizes.add(size);
    }
}
```
- 📄 : [[Spring] TransientPropertyValueException: object references an unsaved transient instance](https://yooniversal.github.io/project/post231/)
- [fix: PK 없는 객체 참조하는 문제 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/ff43ecb927a611962c364a733f2dda42e89ead14)

### DB 수정 메소드에 트랜잭션 적용
`Size` 객체 생성 중에 `Top` 또는 `Bottom`을 생성할 때 `saveTop()` 또는 `saveBottom()`을 호출하는데 트랜잭션 내에서 처리되지 않아 DB에 반영이 되지 않아 정상적으로 데이터가 반영되지 않는 문제가 있었습니다. `@Transactional`을 붙여 해결했습니다.
```java
@Transactional
public Size saveTop(TopDto topDto, Product product) {...}
@Transactional
public Size saveBottom(BottomDto bottomDto, Product product) {...}
@Transactional
public void setProduct(Size size, Product product) {...}
```
- [fix: DB 업데이트 메소드에 트랜잭션 적용](https://github.com/YeolJyeongKong/fittering-BE/commit/76d005266075be76df875f26a9108fd6c04d7750)

### Controller에서 데이터를 DTO로 받도록 설정
기존엔 `@ModelAttribute`로 설정했으나 파라미터에서 `Model`을 사용하지 않아 파라미터로 설정한 DTO로 데이터가 정상적으로 입력되지 않는 문제가 있었습니다. `@RequestBody`로 수정하면서 해결할 수 있었습니다.
- [fix: 데이터를 DTO로 직접 받도록 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/77468be79e00cca61c46b3792acd0f0bcdeb74af)

### count 쿼리 null 예외처리
count 쿼리는 `fetchOne()`를 사용하는데 데이터가 없는 경우 `null`을 반환합니다. 이 때 적절히 예외처리를 해주지 않아 API 테스트 시 정상적인 응답을 반환하지 않고 `500` 에러를 발생하는 문제가 있었습니다. `null`일 경우 `0L`을 반환하도록 수정했습니다.
```java
Long nullableCount = queryFactory
        .select(favorite.count())
        .from(favorite)
        .where(
                userIdEq(userId),
                favorite.mall.isNull()
        )
        .fetchOne();

Long count = nullableCount != null ? nullableCount : 0L; //추가

return PageableExecutionUtils.getPage(content, pageable, () -> count);
```
-  📄: [[Spring] Cannot invoke “java.lang.Long.longValue()” because “count” is null](https://yooniversal.github.io/project/post241/)
- [fix: fetchOne() 반환 값 null 예외 처리](https://github.com/YeolJyeongKong/fittering-BE/commit/fd87f7105c8758353d265f04d64847f66b9bee50)

### redis 캐시 직렬화
redis 캐시에 데이터를 저장하거나 가져올 때 직렬화/역직렬화를 거치는데 연관 엔티티를 참조하는 과정에서 에러가 발생했습니다.
이외에도 `LocalDateTime` 필드를 직렬화 하는 과정에서도 같은 에러가 발생합니다.
```
org.springframework.data.redis.serializer.SerializationException: Could not write JSON: No serializer found for class org.hibernate.proxy.pojo.bytebuddy.ByteBuddyInterceptor and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS) (through reference chain: yeolJyeongKong.mall.domain.entity.Product["category"]->yeolJyeongKong.mall.domain.entity.Category$HibernateProxy$JKB5cUnl["hibernateLazyInitializer"])] with root cause
org.springframework.data.redis.serializer.SerializationException: Could not write JSON: Java 8 date/time type `java.time.LocalDateTime` not supported by default: add Module
```
에러가 발생하는 연관 엔티티에는 `@JsonIgnore`를,
`LocalDateTime` 필드에는 `@JsonSerialize`, `@JsonDeserialize`를 적용해서 해결했습니다.
```java
public class Product {
    ...
    @JsonIgnore //추가
    @ManyToOne(fetch = LAZY)
    @JoinColumn(name = "category_id")
    private Category category;
}

public class Recent {
    ...
    @JsonSerialize(using = LocalDateTimeSerializer.class) //추가
    @JsonDeserialize(using = LocalDateTimeDeserializer.class) //추가
    @NonNull
    private LocalDateTime timestamp;
}
```
- 📄 : [[Spring] cannot deserialize from Object value - LocalDateTime](https://yooniversal.github.io/project/post223/#localdatetime)
- [fix: redis 직렬화 에러 해결](https://github.com/YeolJyeongKong/fittering-BE/commit/3e0b4ca8702756ca0fff6473ea189ab62d981141)

### 엔티티 관계 재설정
최근 본 상품 `Recent`, 최근 본 상품 기반 추천 `RecentRecommendation`, 비슷한 유저 기반 추천 `UserRecommendation`에서 `User`, `Product`의 연관관계 설정이 잘못된걸 테스트 중에 확인해 수정했습니다. 모두 `User`와 `Product` 중간에서 **N:N 관계를 풀어내는 엔티티 역할**을 하게됩니다. 해당 엔티티들에 대해 테스트까지 완료했습니다.
```java
public class Recent {
    ...
    @ManyToOne(fetch = LAZY)
    @JoinColumn(name = "user_id")
    private User user;

    @ManyToOne(fetch = LAZY)
    @JoinColumn(name = "product_id")
    private Product product;
}
```
- [fix: 엔티티 관계 재설정](https://github.com/YeolJyeongKong/fittering-BE/commit/f824cdab9596d004f0251d42ccad22c786366204)
- [test: 엔티티 관계 재설정 관련 테스트](https://github.com/YeolJyeongKong/fittering-BE/commit/d285ddbdff33c70b733e18f5180bb44a88e18686)