### PR TITLE
버그 수정 : 필터링, API

### DIFF
--- a/src/main/java/yeolJyeongKong/mall/controller/MallController.java
+++ b/src/main/java/yeolJyeongKong/mall/controller/MallController.java
@@ -34,7 +34,7 @@ public class MallController {
 
     @Operation(summary = "쇼핑몰 등록 메소드")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"쇼핑몰 등록 완료\"")))
-    @GetMapping("/malls/add")
+    @PostMapping("/malls/add")
     public ResponseEntity<?> save(@RequestBody MallDto mallDto) {
         mallService.save(mallDto);
         return new ResponseEntity<>("쇼핑몰 등록 완료", HttpStatus.OK);

--- a/src/main/java/yeolJyeongKong/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/yeolJyeongKong/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -364,11 +364,14 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     /**
      * @param gender
-     * null     : 전체
-     * not null : 이외 성별 구분
+     * 'M', 'F' : 남성, 여성
+     * else     : 성별 무관
      */
     public BooleanExpression genderEq(String gender) {
-        return StringUtils.hasText(gender) ? product.gender.eq(gender) : Expressions.asBoolean(true).isTrue();
+        if(gender.equals("M") || gender.equals("F")) {
+            return product.gender.eq(gender);
+        }
+        return Expressions.asBoolean(true).isTrue();
     }
 
     public BooleanExpression productNameCotnains(String productName) {


### PR DESCRIPTION
## 버그 수정
### 성별 필터링
전체 API 테스트 중(#19) 성별 필터링이 정상적으로 처리되지 않는 문제가 있었습니다.
성별이 `M`, `F`인 경우에는 정상적으로 동작했으나, 그렇지 않은 경우 성별 무관으로 처리되지 않고 반드시 일치하는 상품만 찾는걸 확인했습니다. `M`, `F` 외 다른 값이 오는 경우 성별 무관 즉, **모든 상품을 대상으로 조회하도록** 수정했습니다.
```java
/**
 * @param gender
 * 'M', 'F' : 남성, 여성
 * else     : 성별 무관
 */
public BooleanExpression genderEq(String gender) {
    if(gender.equals("M") || gender.equals("F")) {
        return product.gender.eq(gender);
    }
    return Expressions.asBoolean(true).isTrue();
}
```
- [fix: 성별 필터링 기능 버그 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/61dd0d10d5579b2f71fdee3e0e3913ce8796c6c1)

### API
쇼핑몰 등록 API이므로 `GET`에서 `POST`로 수정 후 테스트 완료했습니다.
```java
@PostMapping("/malls/add") //수정
public ResponseEntity<?> save(@RequestBody MallDto mallDto) {
    mallService.save(mallDto);
    return new ResponseEntity<>("쇼핑몰 등록 완료", HttpStatus.OK);
}
```
- [fix: 잘못 설정한 HTTP 메소드 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/1c3504236196ad60484441b38b72913ac8cf4f5b)