### PR TITLE
추가 구현 및 리팩토링 : 조회수

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -156,10 +156,10 @@ public class ProductController {
     @GetMapping("/product/{productId}")
     public ResponseEntity<?> productDetail(@PathVariable("productId") Long productId,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        productService.updateView(productId); //상품 조회수
-        rankService.updateViewOnProduct(principalDetails.getUser().getId(), productId); //유저가 조회한 상품의 쇼핑몰 조회수
-        userService.saveRecentProduct(principalDetails.getUser().getId(), productId); //최근 본 상품 업데이트
         Product product = productService.findById(productId);
+        productService.updateView(productId);
+        rankService.updateViewOnMall(principalDetails.getUser().getId(), product.getMall().getId());
+        userService.saveRecentProduct(principalDetails.getUser().getId(), productId);
 
         if(product.getType().equals(OUTER)) {
             ResponseOuterDto outerProduct = productService.outerProductDetail(productId);

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -101,4 +101,8 @@ public class Product {
     public void updateTimeView() {
         timeView = timeView + 1;
     }
+
+    public void initializeTimeView() {
+        timeView = 0;
+    }
 }

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -97,4 +97,8 @@ public class Product {
     public void updateView() {
         view = view + 1;
     }
+
+    public void updateTimeView() {
+        timeView = timeView + 1;
+    }
 }

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -95,11 +95,11 @@ public class Product {
     }
 
     public void updateView() {
-        view = view + 1;
+        view++;
     }
 
     public void updateTimeView() {
-        timeView = timeView + 1;
+        timeView++;
     }
 
     public void initializeTimeView() {

--- a/src/main/java/fittering/mall/scheduler/ViewScheduler.java
+++ b/src/main/java/fittering/mall/scheduler/ViewScheduler.java
@@ -1,0 +1,19 @@
+package fittering.mall.scheduler;
+
+import fittering.mall.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class ViewScheduler {
+
+    private final ProductService productService;
+    private final int day = 1000 * 60 * 60 * 24;
+
+    @Scheduled(fixedDelay = day)
+    public void initializeTimeView() {
+        productService.initializeTimeView();
+    }
+}

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -150,6 +150,7 @@ public class ProductService {
     public void updateView(Long productId) {
         Product product = findById(productId);
         product.updateView();
+        product.updateTimeView();
     }
 
     @Transactional

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -202,4 +202,9 @@ public class ProductService {
         });
         return result;
     }
+
+    @Transactional
+    public void initializeTimeView() {
+        productRepository.findAll().forEach(Product::initializeTimeView);
+    }
 }

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -24,7 +24,8 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class RankService {
 
-    private static final int INITIAL_VIEW = 1;
+    private static final int INITIAL_VIEW = 0;
+    private static final int FIRST_VIEW = 1;
     private static final int MAX_PRODUCT_COUNT = 5;
     private final UserRepository userRepository;
     private final MallRepository mallRepository;
@@ -40,7 +41,7 @@ public class RankService {
         return rankRepository.save(Rank.builder()
                                     .user(user)
                                     .mall(mall)
-                                    .view(0)
+                                    .view(INITIAL_VIEW)
                                     .build());
     }
 
@@ -101,7 +102,7 @@ public class RankService {
         rankRepository.save(Rank.builder()
                                 .user(user)
                                 .mall(mall)
-                                .view(INITIAL_VIEW)
+                                .view(FIRST_VIEW)
                                 .build());
     }
 

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -24,6 +24,7 @@ import java.util.Optional;
 @RequiredArgsConstructor
 public class RankService {
 
+    private static final int INITIAL_VIEW = 1;
     private static final int MAX_PRODUCT_COUNT = 5;
     private final UserRepository userRepository;
     private final MallRepository mallRepository;
@@ -100,7 +101,7 @@ public class RankService {
         rankRepository.save(Rank.builder()
                                 .user(user)
                                 .mall(mall)
-                                .view(1)
+                                .view(INITIAL_VIEW)
                                 .build());
     }
 

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -84,29 +84,6 @@ public class RankService {
     }
 
     @Transactional
-    public void updateViewOnProduct(Long userId, Long productId) {
-        Product product = productRepository.findById(productId)
-                .orElseThrow(() -> new NoResultException("product doesn't exist"));
-        Optional<Rank> optionalRank = rankRepository.findByUserIdAndMallId(userId, product.getMall().getId());
-
-        if (optionalRank.isPresent()) {
-            Rank rank = optionalRank.get();
-            rank.updateView();
-            return;
-        }
-
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new NoResultException("user doesn't exist"));
-        Mall mall = mallRepository.findById(product.getMall().getId())
-                .orElseThrow(() -> new NoResultException("mall doesn't exist"));
-        rankRepository.save(Rank.builder()
-                                .user(user)
-                                .mall(mall)
-                                .view(1)
-                                .build());
-    }
-
-    @Transactional
     public void updateViewOnMall(Long userId, Long mallId) {
         Optional<Rank> optionalRank = rankRepository.findByUserIdAndMallId(userId, mallId);
 

--- a/src/test/java/fittering/mall/service/RankServiceTest.java
+++ b/src/test/java/fittering/mall/service/RankServiceTest.java
@@ -142,8 +142,8 @@ class RankServiceTest {
         assertThat(productDto.get(0).getProductId()).isEqualTo(product4.getId());
         assertThat(productDto.get(0).getProductImage()).isEqualTo(product4.getImage());
 
-        rankService.updateViewOnProduct(user.getId(), product.getId());
-        rankService.updateViewOnProduct(user.getId(), product4.getId());
+        rankService.updateViewOnMall(user.getId(), product.getMall().getId());
+        rankService.updateViewOnMall(user.getId(), product4.getMall().getId());
 
         rank1 = rankService.findById(rank1.getId());
         rank2 = rankService.findById(rank2.getId());


### PR DESCRIPTION
## 추가 구현
상품 조회 시 상품 및 쇼핑몰에 대한 누적 조회수가 카운트되도록 구현돼 있었으나 상품 관련 실시간 조회수는 업데이트되고 있지 않았습니다.
해당 기능을 지원하기 위해 `Product` 클래스 내에 `updateTimeView()` 메소드를 구현했으며 상품 조회 API 호출 시 실시간 조회수 `timeView`도 같이 카운트되도록 설정했습니다.
```java
public void updateTimeView() {
    timeView++;
}
```
- [feat: 상품 조회 시 실시간 조회수 업데이트 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/108494c12366ed63a0bfc945a16a215ec6934bf0)

실시간 조회수 `timeView` 초기화 주기를 **하루**로 설정했으며 하루마다 초기화가 이뤄지도록 `ViewScheduler`에서
`initializeTimeView()`를 호출합니다. 이 때 모든 상품의 `timeView`는 `0`으로 초기화됩니다.
```java
@Component
@RequiredArgsConstructor
public class ViewScheduler {

    private final ProductService productService;
    private final int day = 1000 * 60 * 60 * 24;

    @Scheduled(fixedDelay = day)
    public void initializeTimeView() {
        productService.initializeTimeView(); //전체 Product의 timeView 초기화
    }
}
```
- [feat: 상품 실시간 조회수 초기화 기능 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/577cab9b82fd3e4e420bad885c69d3aca235de3b)

## 리팩토링
### 중복 함수 제거
`updateViewOnMall()`과 파라미터는 다르지만 내부 로직은 동일한 함수 `updateViewOnProduct()`가 있어 삭제했습니다.
- [refactor: 같은 역할하는 함수 제거](https://github.com/YeolJyeongKong/fittering-BE/commit/43e80b7fec6bc34dfc392c997342f5d88033ccf2)

### 조회수 초기화 상수 설정
상품 첫 조회 시 조회수는 반드시 `1`이므로 상수 `FIRST_VIEW`로 정의 후 설정했습니다.
상품 저장 시 적용되는 조회수 `0`은 `INITIAL_VIEW`로 대체했습니다.
- [refactor: 같은 역할하는 함수 제거](https://github.com/YeolJyeongKong/fittering-BE/commit/43e80b7fec6bc34dfc392c997342f5d88033ccf2)
- [refactor: 초기값 상수 정의 및 이름 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/9b59daa100bf98c1cf82a0f8c12e0647e1b8ace8)

### 내부 로직 수정
조회수 `view`와 실시간 조회수 `timeView`를 업데이트하는 메소드에서 내부 로직을 보다 간단하게 수정했습니다.
- [refactor: 보다 간단한 로직으로 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/0e2de6729ab3d16d02b31c224d1cd75c188441ea)