### PR TITLE
로그인/회원가입 API : CORS 에러

### DIFF
--- a/src/main/java/fittering/mall/config/CorsConfig.java
+++ b/src/main/java/fittering/mall/config/CorsConfig.java
@@ -12,7 +12,6 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000",
                                 "https://fit-tering.com",
-                                "https://www.fit-tering.com")
-                .allowedMethods("GET", "POST", "DELETE");
+                                "https://www.fit-tering.com");
     }
 }

--- a/src/main/java/fittering/mall/config/CorsConfig.java
+++ b/src/main/java/fittering/mall/config/CorsConfig.java
@@ -12,6 +12,7 @@ public class CorsConfig implements WebMvcConfigurer {
         registry.addMapping("/**")
                 .allowedOrigins("http://localhost:3000",
                                 "https://fit-tering.com",
-                                "https://www.fit-tering.com");
+                                "https://www.fit-tering.com")
+                .allowCredentials(true);
     }
 }

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
                                 .requestMatchers("/login", "/signup", "/error").permitAll()
-                                .requestMatchers("/api/v1/login", "api/v1/signup").permitAll()
+                                .requestMatchers("/api/v1/login", "/api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()
 //                                .anyRequest().authenticated()

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
                                 .requestMatchers("/login", "/signup").permitAll()
-                                .requestMatchers("/api/login", "api/signup").permitAll()
+                                .requestMatchers("/api/v1/login", "api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()
 //                                .anyRequest().authenticated()

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -33,7 +33,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
-                                .requestMatchers("/login", "/signup").permitAll()
+                                .requestMatchers("/login", "/signup", "/error").permitAll()
                                 .requestMatchers("/api/v1/login", "api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()


### PR DESCRIPTION
### 일부 API 인증 허용
로그인/회원가입 API는 인증되지 않은 사용자가 접근해도 이용할 수 있도록 해야하므로 시큐리티 설정 클래스 내에 `filterChain()`에서 해당 URI를 예외적으로 허용해주고 있었으나, URI를 이전에 수정(#31)하면서 **허용해준 URI와 매치가 되지 않아** 인증없이는 사용할 수 없는 문제가 발생 했습니다. 변경된 URI로 수정해주었습니다.
```java
SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .csrf((csrf) -> csrf.disable());

        http
                .authorizeHttpRequests((authorizeHttpRequests) ->
                        authorizeHttpRequests
                                .requestMatchers("/login", "/signup").permitAll()
                                .requestMatchers("/api/v1/login", "/api/v1/signup").permitAll() //수정
        ...
}
```
- [fix: 수정된 API URI에 맞게 변경](https://github.com/YeolJyeongKong/fittering-BE/commit/c7d82d674dfecb34a1f7bd40dd3173002b6e9c07)

### CORS 설정 변경
기존에는 HTTP 메소드를 POST, GET, DELETE만 허용했으나, 모두 허용하도록 수정했습니다.
그리고 JWT 인증 과정에 문제가 없게 하기위해 `allowCredentials(true)`를 추가했습니다.
- [fix: 모든 HTTP 메소드 허용](https://github.com/YeolJyeongKong/fittering-BE/commit/8eebfe987a2baebfeb78b74b78639b010ba9d657)
- [fix: allowCredentials 허용](https://github.com/YeolJyeongKong/fittering-BE/commit/6d2aa1722083b40c9e557631770bd6b393c9b060)

### 에러 페이지 확인할 수 있게 수정
CORS 에러 외에도 다른 에러 발생 시 어떤 에러가 발생했는지 응답이 와야하는데 빈 내용의 body만 도착하는 문제가 있었습니다.
브라우저 접속 시에도 에러 페이지가 아닌 빈 페이지로 이동해 `/error` 페이지를 인증없이도 접근할 수 있도록 수정했습니다.
```java
http
      .authorizeHttpRequests((authorizeHttpRequests) ->
              authorizeHttpRequests
                      .requestMatchers("/login", "/signup", "/error").permitAll()
```
- [fix: error 페이지 인증없이 조회 허용](https://github.com/YeolJyeongKong/fittering-BE/commit/169b106933d2e2bad432f28d11f9ff78c9d40542)