### PR TITLE
인증 필요 API : JWT 에러

### DIFF
--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -42,7 +42,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/login", "/api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()
-                                .anyRequest().authenticated()
+                                .anyRequest().hasRole("USER")
 //                                .anyRequest().permitAll()
                 )
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -10,6 +10,7 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
@@ -31,7 +32,8 @@ public class SecurityConfig {
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http
                 .httpBasic(AbstractHttpConfigurer::disable)
-                .csrf(AbstractHttpConfigurer::disable);
+                .csrf(AbstractHttpConfigurer::disable)
+                .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS));
 
         http
                 .authorizeHttpRequests((authorizeHttpRequests) ->

--- a/src/main/java/fittering/mall/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtTokenProvider.java
@@ -68,6 +68,6 @@ public class JwtTokenProvider {
 
     //request의 header에서 token 값 가져오기
     public String resolveToken(HttpServletRequest request) {
-        return request.getHeader("X-AUTH-TOKEN");
+        return request.getHeader("Authorization");
     }
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/request/RequestMallDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/request/RequestMallDto.java
@@ -12,7 +12,6 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RequestMallDto {
-    private Long id;
     private String name;
     private String url;
     private String image;

--- a/src/main/java/fittering/mall/service/UserService.java
+++ b/src/main/java/fittering/mall/service/UserService.java
@@ -49,7 +49,7 @@ public class UserService {
     public User save(SignUpDto signUpDto) {
         Measurement measurement = measurementRepository.save(new Measurement());
         User user = UserMapper.INSTANCE.toUser(signUpDto, getAgeRange(signUpDto.getYear(), signUpDto.getMonth(), signUpDto.getDay()),
-                passwordEncoder.encode(signUpDto.getPassword()), measurement, new ArrayList<>(List.of("USER")));
+                passwordEncoder.encode(signUpDto.getPassword()), measurement, new ArrayList<>(List.of("ROLE_USER")));
         return userRepository.save(user);
     }
 


### PR DESCRIPTION
### 세션 비활성화
인증 방식을 세션이 아닌 JWT를 이용할 것이기 때문에 `filterChain()`에서 비활성화했습니다.
```java
http
      .httpBasic(AbstractHttpConfigurer::disable)
      .csrf(AbstractHttpConfigurer::disable)
      .sessionManagement((session) -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS)); //추가
```
<br>

### JWT 값이 null로 넘어오는 현상
로그인 후 발급받은 토큰을 헤더에 넣어준 뒤 API 테스트를 했을 때 `403` 에러가 발생했습니다.
`resolveToken()`에서 토큰 정보를 읽어오는데 `null` 값을 반환하는걸 확인했고 **잘못된 헤더 필드를 참조**한게 원인이었습니다.
[fittering-FE](https://github.com/YeolJyeongKong/fittering-FE)에서 `Authorization` 필드를 참조하도록 설정했기 때문에 이에 맞게 수정했습니다.
```java
public class JwtTokenProvider {
  ...
  public String resolveToken(HttpServletRequest request) {
      return request.getHeader("Authorization");
  }
}
```
- [fix: 토큰 헤더 필드 재설정](https://github.com/YeolJyeongKong/fittering-BE/commit/f56c461524afb754e919ea9dd3508a5c04b43b7b)

### 권한 재설정
기존에는 신규 사용자 정보를 저장할 때 권한 정보를 `USER`로 저장했는데 JWT 설정을 마쳤음에도 `403` 에러가 발생했습니다.
스프링 시큐리티 `hasRole()`에서 권한을 체크할 때 **접두어** `ROLE_`**을 제거**한다는걸 알게됐고 신규 사용자 저장 시 권한을
`ROLE_USER`로 저장하니 문제없이 인증이 되는걸 확인할 수 있었습니다.
- [fix: 권한이 USER일 때만 통과하도록 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/7c20f4caa3615b3ff12ce55382ae388ec2893cda)
- [fix: 회원가입 시 입력되는 권한 정보 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/bc09612b33f54598c68b009cded3efffcdd8f5ae)
- 📄 : [[Spring] JWT를 적용하면서 발생한 에러 정리](https://yooniversal.github.io/project/post249/)