### PR TITLE
preflight request : CORS 에러

### DIFF
--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -16,8 +16,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 import fittering.mall.config.jwt.JwtTokenProvider;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
-
-import static org.springframework.security.config.Customizer.withDefaults;
+import org.springframework.web.cors.CorsUtils;
 
 @Slf4j
 @Configuration
@@ -38,6 +37,7 @@ public class SecurityConfig {
         http
                 .authorizeHttpRequests((authorizeHttpRequests) ->
                         authorizeHttpRequests
+                                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll()
                                 .requestMatchers("/login", "/signup", "/error").permitAll()
                                 .requestMatchers("/api/v1/login", "/api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()


### PR DESCRIPTION
## preflight request : CORS 정책 위반
### preflight request이란?
본 요청을 보내기 전에 먼저 `OPTIONS` 메서드를 통해 HTTP 요청을 보내 **실제 요청이 전송하기에 안전한지 확인하는 방식**을 말합니다.

### 문제 상황
배포 후 [fittering-FE](https://github.com/YeolJyeongKong/fittering-FE) 로컬에서 테스트 시 다음 에러가 발생했습니다.
> Access to fetch at 'https://fit-tering.com/api/v1/malls/1' from origin 'http://localhost:3000' has been blocked by CORS policy: Response to preflight request doesn't pass access control check: Redirect is not allowed for a preflight request.

### 해결
스프링 시큐리티 설정 클래스 `SecurityConfig`에서 `CorsUtils.isPreFlightRequest()`에 true인 모든 request에 대해
별도 인증이 필요하지 않도록 `permitAll()`을 설정했습니다.
```java
.authorizeHttpRequests((authorizeHttpRequests) ->
                        authorizeHttpRequests
                                .requestMatchers(CorsUtils::isPreFlightRequest).permitAll() //추가
...
```

아래는 `CorsUtils.isPreFlightRequest()` 내용으로,
`request`에 대해 3가지를 체크하고 하나라도 만족하지 않을 시 `false`를 리턴합니다.
```java
public static boolean isPreFlightRequest(HttpServletRequest request) {
return (HttpMethod.OPTIONS.matches(request.getMethod()) && //HTTP 메소드가 OPTIONS인지
		request.getHeader(HttpHeaders.ORIGIN) != null && //헤더에 origin 필드가 비어있는지
		request.getHeader(HttpHeaders.ACCESS_CONTROL_REQUEST_METHOD) != null); //헤더에 Access-Control-Request-Method가 비어있는지
}
```
