### PR TITLE
Redis 캐시 : 조회수 배치 업데이트 설정

### DIFF
--- a/src/main/java/fittering/mall/config/cache/RedisConfig.java
+++ b/src/main/java/fittering/mall/config/cache/RedisConfig.java
@@ -6,6 +6,9 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 public class RedisConfig {
@@ -19,5 +22,14 @@ public class RedisConfig {
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
         return new LettuceConnectionFactory(new RedisStandaloneConfiguration(host, port));
+    }
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate() {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(redisConnectionFactory());
+        redisTemplate.setKeySerializer(new StringRedisSerializer());
+        redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return redisTemplate;
     }
 }

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -98,8 +98,16 @@ public class Product {
         view++;
     }
 
+    public void updateView(Integer view) {
+        this.view += view;
+    }
+
     public void updateTimeView() {
         timeView++;
+    }
+
+    public void updateTimeView(Integer timeView) {
+        this.timeView += timeView;
     }
 
     public void initializeTimeView() {

--- a/src/main/java/fittering/mall/domain/entity/Rank.java
+++ b/src/main/java/fittering/mall/domain/entity/Rank.java
@@ -40,7 +40,7 @@ public class Rank {
         this.view = view;
     }
 
-    public void updateView() {
-        view++;
+    public void updateView(Integer view) {
+        this.view += view;
     }
 }

--- a/src/main/java/fittering/mall/scheduler/ViewScheduler.java
+++ b/src/main/java/fittering/mall/scheduler/ViewScheduler.java
@@ -1,6 +1,7 @@
 package fittering.mall.scheduler;
 
 import fittering.mall.service.ProductService;
+import fittering.mall.service.RedisService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
@@ -10,10 +11,17 @@ import org.springframework.stereotype.Component;
 public class ViewScheduler {
 
     private final ProductService productService;
+    private final RedisService redisService;
     private final int day = 1000 * 60 * 60 * 24;
+    private final int hour = 1000 * 60 * 60;
 
     @Scheduled(fixedDelay = day)
     public void initializeTimeView() {
         productService.initializeTimeView();
+    }
+
+    @Scheduled(fixedDelay = hour)
+    public void batchUpdateView() {
+        redisService.batchUpdateView();
     }
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -30,6 +30,7 @@ public class ProductService {
     private final UserRecommendationRepository userRecommendationRepository;
     private final DescriptionImageRepository descriptionImageRepository;
     private final SubCategoryRepository subCategoryRepository;
+    private final RedisService redisService;
 
     @Transactional
     public Product save(Product product) {
@@ -146,11 +147,9 @@ public class ProductService {
         return SizeMapper.INSTANCE.toResponseBottomDto(productRepository.bottomProductDetail(productId));
     }
 
-    @Transactional
     public void updateView(Long productId) {
-        Product product = findById(productId);
-        product.updateView();
-        product.updateTimeView();
+        redisService.updateViewOfProduct(productId);
+        redisService.updateTimeViewOfProduct(productId);
     }
 
     @Transactional

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -31,6 +31,7 @@ public class RankService {
     private final MallRepository mallRepository;
     private final RankRepository rankRepository;
     private final ProductRepository productRepository;
+    private final RedisService redisService;
 
     @Transactional
     public Rank save(Long userId, Long mallId) {
@@ -90,8 +91,8 @@ public class RankService {
         Optional<Rank> optionalRank = rankRepository.findByUserIdAndMallId(userId, mallId);
 
         if(optionalRank.isPresent()) {
-            Rank rank = optionalRank.get();
-            rank.updateView();
+            Long rankId = optionalRank.get().getId();
+            redisService.batchUpdateViewOfRank(rankId);
             return;
         }
 

--- a/src/main/java/fittering/mall/service/RedisService.java
+++ b/src/main/java/fittering/mall/service/RedisService.java
@@ -1,0 +1,65 @@
+package fittering.mall.service;
+
+import fittering.mall.repository.ProductRepository;
+import fittering.mall.repository.RankRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class RedisService {
+    
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ProductRepository productRepository;
+    private final RankRepository rankRepository;
+
+    public void updateViewOfProduct(Long productId) {
+        redisTemplate.opsForValue().increment("Batch:Product_view_" + productId);
+    }
+
+    public void updateTimeViewOfProduct(Long productId) {
+        redisTemplate.opsForValue().increment("Batch:Product_timeView_" + productId);
+    }
+
+    public void batchUpdateViewOfRank(Long RankId) {
+        redisTemplate.opsForValue().increment("Batch:Rank_view_" + RankId);
+    }
+
+    @Transactional
+    public void batchUpdateView() {
+        redisTemplate.keys("Batch:Product_view_*").forEach(key -> {
+            Long productId = Long.parseLong(key.split("_")[1]);
+            Integer view = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());
+
+            productRepository.findById(productId).ifPresent(product -> {
+                product.updateView(view);
+            });
+
+            redisTemplate.delete(key);
+        });
+
+        redisTemplate.keys("Batch:Product_timeView_*").forEach(key -> {
+            Long productId = Long.parseLong(key.split("_")[1]);
+            Integer timeView = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());
+
+            productRepository.findById(productId).ifPresent(product -> {
+                product.updateTimeView(timeView);
+            });
+
+            redisTemplate.delete(key);
+        });
+
+        redisTemplate.keys("Batch:Rank_view_*").forEach(key -> {
+            Long rankId = Long.parseLong(key.split("_")[1]);
+            Integer view = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());
+
+            rankRepository.findById(rankId).ifPresent(rank -> {
+                rank.updateView(view);
+            });
+
+            redisTemplate.delete(key);
+        });
+    }
+}


### PR DESCRIPTION
## 배치 업데이트
사용자는 상품 상세 조회 또는 쇼핑몰 조회 시 조회수 `view`를 업데이트하도록 설정했었습니다. 하지만 이 작업이 DB에 영향을 주기 때문에 매번 호출되도록 설정해둔다면 사용자가 많아졌을 때 서버에 부하가 심해질거라 판단이 들어 조회수를 업데이트하는 작업들을 일정 시간동안 모았다가 DB에 한 번에 반영하는 **배치 업데이트**가 필요하다고 생각했고, **Redis 캐시**와 **Scheduler**를 활용해 구현했습니다.
- 📄: [[Spring] Redis 캐시를 활용해 데이터 주기적으로 반영하기](https://yooniversal.github.io/project/post251/)

### RedisTemplate 빈 등록
`RedisService`에서 주입받아 사용할 수 있도록 `RedisTemplate`을 빈으로 등록했습니다.
Redis 컨테이너에 접근해 데이터를 반영하거나 가져올 수 있도록 하는 중간 역할을 하게 됩니다.
- [feat: RedisTemplate 빈 등록](https://github.com/YeolJyeongKong/fittering-BE/commit/c6b53d15fdb38000a1a16a31ec1e75f5c3d2480a)


### key 설정
`Redis` 캐시에 `key-value`로 등록할 것이기 때문에 조회수를 업데이트하는 **작업 단위를 구분해야 합니다.**
다음 3가지 작업 단위가 있으며, `key` 값은 다음과 같이 설정했습니다.

- Product
  + 조회수 **view** : `Batch:Product_view_{productId}`
  + 실시간 조회수 **timeView** : `Batch:Product_timeView_{productId}`
- Rank
  + 조회수 **view** : `Batch:Rank_view_{rankId}`

### Scheduler 설정
조회수를 업데이트하는 모든 작업은 Redis 캐시 즉, `RedisTemplate`에 저장됩니다.
Scheduler를 통해 **1시간**마다 `RedisTemplate`에 저장된 모든 작업을 수행하고 초기화하도록 설정했습니다.
DB 반영 주기는 팀 내 협의를 통해 추후 수정될 수 있습니다.
```java
@Transactional
//캐시에 저장된 조회수 업데이트 작업들을 DB에 반영
public void batchUpdateView() {
    redisTemplate.keys("Batch:Product_view_*").forEach(key -> {
        Long productId = Long.parseLong(key.split("_")[1]);
        Integer view = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());

        productRepository.findById(productId).ifPresent(product -> {
            product.updateView(view);
        });

        redisTemplate.delete(key);
    });
    ...
}

//1시간마다 위 작업 모두 수행
@Scheduled(fixedDelay = hour)
public void batchUpdateView() {
    redisService.batchUpdateView();
}
```
- [feat: redis 캐시에 반영 후 삭제하도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/0bc7eba40cee8b5641e8c5584917d6ae6ea2643e)
- [feat: 1시간마다 조회수 배치 업데이트 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/c479b2a44820fd7e65e70048fbda29de8f531906)