### PR TITLE
DTO 수정 : 쇼핑몰 미리보기에 제공되는 필드 수정

### DIFF
--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallPreviewDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallPreviewDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResponseMallPreviewDto {
+    private Long id;
     private String name;
-    private String url;
     private String image;
 }

--- a/src/main/java/fittering/mall/domain/dto/repository/SavedMallPreviewDto.java
+++ b/src/main/java/fittering/mall/domain/dto/repository/SavedMallPreviewDto.java
@@ -9,14 +9,14 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 public class SavedMallPreviewDto {
+    private Long id;
     private String name;
-    private String url;
     private String image;
 
     @QueryProjection
-    public SavedMallPreviewDto(String name, String url, String image) {
+    public SavedMallPreviewDto(Long id, String name, String image) {
+        this.id = id;
         this.name = name;
-        this.url = url;
         this.image = image;
     }
 }

--- a/src/main/java/fittering/mall/domain/dto/service/MallPreviewDto.java
+++ b/src/main/java/fittering/mall/domain/dto/service/MallPreviewDto.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MallPreviewDto {
+    private Long id;
     private String name;
-    private String url;
     private String image;
 }

--- a/src/main/java/fittering/mall/repository/querydsl/RankRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/RankRepositoryImpl.java
@@ -29,8 +29,8 @@ public class RankRepositoryImpl implements RankRepositoryCustom {
     public List<MallPreviewDto> mallRankPreview(Long userId, Pageable pageable, int count) {
         List<SavedMallPreviewDto> savedMallPreviewDtos = queryFactory
                 .select(new QSavedMallPreviewDto(
+                        mall.id,
                         mall.name,
-                        mall.url,
                         mall.image
                 ))
                 .from(rank)


### PR DESCRIPTION
### ResponseMallPreviewDto
기존에는 쇼핑몰의 원주소 `url`을 제공하고 있었으나 쇼핑몰 미리보기 제공 시 원주소를 **설정할 곳이 없으므로** 삭제했습니다.
쇼핑몰 PK인 `id`의 경우 Fittering 서비스 내 **특정 쇼핑몰 링크로 이동할 수 있도록** 활용할 수 있으므로 추가했습니다.
```java
//Before
public class ResponseMallPreviewDto {
    private String name;
    private String url;
    private String image;
}

//After
public class ResponseMallPreviewDto {
    private Long id;
    private String name;
    private String image;
}
```

Controller, Service, Repository 각 레벨에서 사용되는 DTO가 다르므로 다음 3개 클래스를 모두 수정했습니다.
변경 사항은 모두 같습니다.
- `ResponseMallPreviewDto`
- `MallPreviewDto`
- `SavedMallPreviewDto` : 변경된 DTO를 생성할 수 있도록 Repository 로직도 수정