### PR TITLE
API 구현 : 실시간 랭킹순 조회, 연관검색어, 좋아요

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -183,6 +183,14 @@ public class ProductController {
         return new ResponseEntity<>("정의된 타입 없음", HttpStatus.BAD_REQUEST);
     }
 
+    @Operation(summary = "실시간 랭킹순 상품 조회")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
+    @GetMapping("/products/rank")
+    public ResponseEntity<?> productOfTimeRank() {
+        List<ResponseProductPreviewDto> productsOfTimeRank = productService.productsOfTimeRank();
+        return new ResponseEntity<>(productsOfTimeRank, HttpStatus.OK);
+    }
+
     private void getSizesOfOuter(RequestProductDetailDto productDto, Product product) {
         productDto.getOuterSizes().forEach(requestOuterDto ->
                 sizeService.saveOuter(SizeMapper.INSTANCE.toOuterDto(requestOuterDto), product));

--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -185,9 +185,9 @@ public class ProductController {
 
     @Operation(summary = "실시간 랭킹순 상품 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/products/rank")
-    public ResponseEntity<?> productOfTimeRank() {
-        List<ResponseProductPreviewDto> productsOfTimeRank = productService.productsOfTimeRank();
+    @GetMapping("/products/rank/{gender}")
+    public ResponseEntity<?> productOfTimeRank(@PathVariable("gender") String gender) {
+        List<ResponseProductPreviewDto> productsOfTimeRank = productService.productsOfTimeRank(gender);
         return new ResponseEntity<>(productsOfTimeRank, HttpStatus.OK);
     }
 

--- a/src/main/java/fittering/mall/controller/SearchController.java
+++ b/src/main/java/fittering/mall/controller/SearchController.java
@@ -1,6 +1,7 @@
 package fittering.mall.controller;
 
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
+import fittering.mall.domain.dto.controller.response.ResponseRelatedSearchDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -16,6 +17,8 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import fittering.mall.service.SearchService;
+
+import java.util.List;
 
 @Tag(name = "검색", description = "검색 서비스 관련 API")
 @RestController
@@ -33,6 +36,17 @@ public class SearchController {
                                     @PathVariable("filterId") Long filterId,
                                     Pageable pageable) {
         Page<ResponseProductPreviewDto> result = searchService.products(keyword, gender, filterId, pageable);
+        return new ResponseEntity<>(result, HttpStatus.OK);
+    }
+
+    @Operation(summary = "연관검색어")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseRelatedSearchDto.class)))
+    @GetMapping("/search/{keyword}")
+    public ResponseEntity<?> relatedSearch(@PathVariable("keyword") String keyword) {
+        ResponseRelatedSearchDto result = ResponseRelatedSearchDto.builder()
+                .products(searchService.relatedSearchProducts(keyword))
+                .malls(searchService.relatedSearchMalls(keyword))
+                .build();
         return new ResponseEntity<>(result, HttpStatus.OK);
     }
 }

--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -101,8 +101,7 @@ public class UserController {
     public ResponseEntity<?> favoriteProduct(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                              Pageable pageable) {
         Page<ResponseProductPreviewDto> products = favoriteService.userFavoriteProduct(
-                                                principalDetails.getUser().getId(), pageable
-                                           );
+                                                principalDetails.getUser().getId(), pageable);
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 

--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -106,6 +106,14 @@ public class UserController {
         return new ResponseEntity<>(products, HttpStatus.OK);
     }
 
+    @Operation(summary = "유저 즐겨찾기 상품 조회 (미리보기)")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
+    @GetMapping("/user/favorite_goods/preview")
+    public ResponseEntity<?> favoriteProductPreview(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        List<ResponseProductPreviewDto> products = favoriteService.userFavoriteProductPreview(principalDetails.getUser().getId());
+        return new ResponseEntity<>(products, HttpStatus.OK);
+    }
+
     @Operation(summary = "유저 즐겨찾기 상품 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"유저 즐겨찾기 상품 등록 완료\"")))
     @PostMapping("/user/favorite_goods/{productId}")

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseRelatedSearchDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseRelatedSearchDto.java
@@ -1,0 +1,17 @@
+package fittering.mall.domain.dto.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseRelatedSearchDto {
+    private List<String> products;
+    private List<String> malls;
+}

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryCustom.java
@@ -10,6 +10,7 @@ import java.util.List;
 public interface FavoriteRepositoryCustom {
     List<Favorite> userFavoriteMall(Long userId);
     Page<ResponseProductPreviewDto> userFavoriteProduct(Long userId, Pageable pageable);
+    List<ResponseProductPreviewDto> userFavoriteProductPreview(Long userId);
     void deleteByUserIdAndMallId(Long userId, Long mallId);
     void deleteByUserIdAndProductId(Long userId, Long productId);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
@@ -60,6 +60,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
                         userIdEq(userId),
                         favorite.mall.isNull()
                 )
+                .orderBy(product.id.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())
                 .fetch();
@@ -97,6 +98,7 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
                         userIdEq(userId),
                         favorite.mall.isNull()
                 )
+                .orderBy(product.id.desc())
                 .limit(PRODUCT_PREVIEW_MAX_SIZE)
                 .fetch();
     }

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
@@ -19,6 +19,7 @@ import static fittering.mall.repository.querydsl.EqualMethod.userIdEq;
 
 public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
 
+    private static int PRODUCT_PREVIEW_MAX_SIZE = 4;
     private JPAQueryFactory queryFactory;
 
     public FavoriteRepositoryImpl(EntityManager em) {
@@ -75,6 +76,29 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
         Long count = nullableCount != null ? nullableCount : 0L;
 
         return PageableExecutionUtils.getPage(content, pageable, () -> count);
+    }
+
+    @Override
+    public List<ResponseProductPreviewDto> userFavoriteProductPreview(Long userId) {
+        return queryFactory
+                .select(new QResponseProductPreviewDto(
+                        product.id.as("productId"),
+                        product.image.as("productImage"),
+                        product.name.as("productName"),
+                        product.price,
+                        mall.name.as("mallName"),
+                        mall.url.as("mallUrl")
+                ))
+                .from(favorite)
+                .join(favorite.user, user)
+                .join(favorite.product, product)
+                .join(product.mall, mall)
+                .where(
+                        userIdEq(userId),
+                        favorite.mall.isNull()
+                )
+                .limit(PRODUCT_PREVIEW_MAX_SIZE)
+                .fetch();
     }
 
     @Override

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryCustom.java
@@ -7,4 +7,5 @@ import java.util.List;
 public interface MallRepositoryCustom {
     List<ResponseProductPreviewDto> findProducts(String mallName);
     Long findFavoriteCount(Long mallId);
+    List<String> relatedSearch(String keyword);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
@@ -52,4 +52,15 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
                 .fetchOne();
         return nullableCount != null ? nullableCount : 0L;
     }
+
+    @Override
+    public List<String> relatedSearch(String keyword) {
+        return queryFactory
+                .select(mall.name)
+                .from(mall)
+                .where(
+                        mall.name.contains(keyword)
+                )
+                .fetch();
+    }
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -28,5 +28,5 @@ public interface ProductRepositoryCustom {
     Long findRecentCount(Long recentId);
     Long findRecentRecommendation(Long recentRecommendationId);
     Long findUserRecommendation(Long userRecommendationId);
-    List<ResponseProductPreviewDto> timeRank();
+    List<ResponseProductPreviewDto> timeRank(String gender);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -15,6 +15,7 @@ public interface ProductRepositoryCustom {
     Page<ResponseProductPreviewDto> productWithCategory(Long mallId, Long categoryId, String gender, Long filterId, Pageable pageable);
     Page<ResponseProductPreviewDto> productWithSubCategory(Long mallId, Long subCategoryId, String gender, Long filterId, Pageable pageable);
     Page<ResponseProductPreviewDto> searchProduct(String productName, String gender, Long filterId, Pageable pageable);
+    List<String> relatedSearch(String keyword);
     Long productCountWithCategory(Long categoryId);
     Long productCountWithSubCategory(Long categoryId);
     Long productCountWithCategoryOfMall(String mallName, Long categoryId);

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -8,6 +8,8 @@ import fittering.mall.domain.dto.service.TopProductDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.util.List;
+
 public interface ProductRepositoryCustom {
     ResponseProductPreviewDto productById(Long productId);
     Page<ResponseProductPreviewDto> productWithCategory(Long mallId, Long categoryId, String gender, Long filterId, Pageable pageable);
@@ -25,4 +27,5 @@ public interface ProductRepositoryCustom {
     Long findRecentCount(Long recentId);
     Long findRecentRecommendation(Long recentRecommendationId);
     Long findUserRecommendation(Long userRecommendationId);
+    List<ResponseProductPreviewDto> timeRank();
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -195,6 +195,17 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
+    public List<String> relatedSearch(String keyword) {
+        return queryFactory
+                .select(product.name)
+                .from(product)
+                .where(
+                        product.name.contains(keyword)
+                )
+                .fetch();
+    }
+
+    @Override
     public Long productCountWithCategory(Long categoryId) {
         Long nullableCount = queryFactory
                 .select(product.count())

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -39,6 +39,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private static final int VIEW_DESC = 1;
     private static final int PRICE_ASC = 2;
     private static final int MOST_POPULAR_TARGET_COUNT = 1;
+    private static final int TIME_RANK_PRODUCT_COUNT = 18;
     private JPAQueryFactory queryFactory;
 
     public ProductRepositoryImpl(EntityManager em) {
@@ -546,6 +547,24 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 )
                 .fetchOne();
         return nullableCount != null ? nullableCount : 0L;
+    }
+
+    @Override
+    public List<ResponseProductPreviewDto> timeRank() {
+        return queryFactory
+                .select(new QResponseProductPreviewDto(
+                        product.id.as("productId"),
+                        product.image.as("productImage"),
+                        product.name.as("productName"),
+                        product.price,
+                        mall.name.as("mallName"),
+                        mall.url.as("mallUrl")
+                ))
+                .from(product)
+                .leftJoin(product.mall, mall)
+                .orderBy(product.view.desc())
+                .limit(TIME_RANK_PRODUCT_COUNT)
+                .fetch();
     }
 
     public OrderSpecifier<? extends Number> filter(Long filterId) {

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -561,7 +561,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public List<ResponseProductPreviewDto> timeRank() {
+    public List<ResponseProductPreviewDto> timeRank(String gender) {
         return queryFactory
                 .select(new QResponseProductPreviewDto(
                         product.id.as("productId"),
@@ -572,6 +572,9 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         mall.url.as("mallUrl")
                 ))
                 .from(product)
+                .where(
+                        genderEq(gender)
+                )
                 .leftJoin(product.mall, mall)
                 .orderBy(product.view.desc())
                 .limit(TIME_RANK_PRODUCT_COUNT)

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -576,7 +576,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                         genderEq(gender)
                 )
                 .leftJoin(product.mall, mall)
-                .orderBy(product.view.desc())
+                .orderBy(product.timeView.desc())
                 .limit(TIME_RANK_PRODUCT_COUNT)
                 .fetch();
     }

--- a/src/main/java/fittering/mall/service/FavoriteService.java
+++ b/src/main/java/fittering/mall/service/FavoriteService.java
@@ -9,6 +9,7 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import fittering.mall.domain.RestPage;
@@ -82,6 +83,10 @@ public class FavoriteService {
 
     public RestPage<ResponseProductPreviewDto> userFavoriteProduct(Long userId, Pageable pageable) {
         return new RestPage<>(favoriteRepository.userFavoriteProduct(userId, pageable));
+    }
+
+    public List<ResponseProductPreviewDto> userFavoriteProductPreview(Long userId) {
+        return favoriteRepository.userFavoriteProductPreview(userId);
     }
 
     @Transactional

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -207,7 +207,7 @@ public class ProductService {
         productRepository.findAll().forEach(Product::initializeTimeView);
     }
 
-    public List<ResponseProductPreviewDto> productsOfTimeRank() {
-        return productRepository.timeRank();
+    public List<ResponseProductPreviewDto> productsOfTimeRank(String gender) {
+        return productRepository.timeRank(gender);
     }
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -206,4 +206,8 @@ public class ProductService {
     public void initializeTimeView() {
         productRepository.findAll().forEach(Product::initializeTimeView);
     }
+
+    public List<ResponseProductPreviewDto> productsOfTimeRank() {
+        return productRepository.timeRank();
+    }
 }

--- a/src/main/java/fittering/mall/service/SearchService.java
+++ b/src/main/java/fittering/mall/service/SearchService.java
@@ -1,6 +1,7 @@
 package fittering.mall.service;
 
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
+import fittering.mall.repository.MallRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
@@ -8,14 +9,27 @@ import org.springframework.stereotype.Service;
 import fittering.mall.domain.RestPage;
 import fittering.mall.repository.ProductRepository;
 
+import java.util.List;
+
 @Service
 @RequiredArgsConstructor
 public class SearchService {
 
     private final ProductRepository productRepository;
+    private final MallRepository mallRepository;
 
     @Cacheable(value = "Search", key = "#productName + '_' + #gender")
     public RestPage<ResponseProductPreviewDto> products(String productName, String gender, Long filterId, Pageable pageable) {
         return new RestPage<>(productRepository.searchProduct(productName, gender, filterId, pageable));
+    }
+
+    @Cacheable(value = "RelatedSearch", key = "'product_' + #keyword")
+    public List<String> relatedSearchProducts(String keyword) {
+        return productRepository.relatedSearch(keyword);
+    }
+
+    @Cacheable(value = "RelatedSearch", key = "'mall_' + #keyword")
+    public List<String> relatedSearchMalls(String keyword) {
+        return mallRepository.relatedSearch(keyword);
     }
 }


### PR DESCRIPTION
## API 구현
### 실시간 랭킹 상품 조회 API
Fittering 메인 페이지 하단에서 **상품의 실시간 조회수 기준 높은순**으로 **18개**를 조회할 수 있습니다.
위 기능에 사용될 API로, `Product.timeView` 기준 내림차순으로 상품 데이터를 최대 18개만큼 가져오도록 설정했습니다.
또한 **성별 정보**를 입력하면 필터링된 상품들을 조회할 수 있습니다.
- API URI : `/products/rank/{gender}`
- [feat: 실시간 랭킹순 상품 조회 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/735a65c54e2d4e48c982102e3b8a2e1291a651f6)
- [feat: 실시간 랭킹순 상품 조회 API에 성별 필터링 기능 적용](https://github.com/YeolJyeongKong/fittering-BE/commit/802282294b15d271884597651cee92a19df4dd09)
- [fix: 실시간 랭킹순 상품 조회 API 기준 재설정](https://github.com/YeolJyeongKong/fittering-BE/commit/3876b2b9f5d966fc8469169bf73d944e38bcc4d0)

### 연관검색어
사용자가 검색 기능에 키워드를 입력할 때마다 연관검색어를 제공하는 API입니다.
`상품`은 **이름에 키워드가 포함**만 되면 조회하도록 설정했고, `쇼핑몰`은 이름이 **키워드로 시작하는 경우**에만 조회하도록 설정했습니다.
키워드를 입력할 때마다 API를 호출하므로 **응답 시간을 빠르게 하기 위해** `Redis Cache`를 적용했습니다.
```java
@Cacheable(value = "RelatedSearch", key = "'product_' + #keyword")
    public List<String> relatedSearchProducts(String keyword) {
    return productRepository.relatedSearch(keyword);
}

@Cacheable(value = "RelatedSearch", key = "'mall_' + #keyword")
    public List<String> relatedSearchMalls(String keyword) {
    return mallRepository.relatedSearch(keyword);
}
```
- API URI : `/products/rank/{gender}`
- [feat: 연관검색어 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/b42e4808d97409d10c53740558e4f16e7a0fdb0a)

### 좋아요한 상품 조회 (미리보기)
좋아요한 상품들을 마이페이지에서 미리보기 형태로 제공하기 위해 API를 구현했습니다.
미리보기에서는 상품을 최대 4개까지 조회할 수 있으므로 API에서도 **최대 4개**까지 상품 정보를 반환합니다.
조회 기준은 **최신순**입니다.
- API URI : `/user/favorite_goods/preview`
- [feat: 유저 즐겨찾기 상품 조회 미리보기 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/023fab5f512b2eaa6feab00abbc3007187052248)
- [feat: 즐겨찾기 상품 조회 기준 최신순으로 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/3234372242ca6423ca57866bc8507785cad60e79)