### PR TITLE
상품 조회 API : 전체 카테고리 구현

### DIFF
--- a/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
+++ b/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
@@ -37,7 +37,10 @@ public class EqualMethod {
     }
 
     public static BooleanExpression categoryIdEq(Long categoryId) {
-        return categoryId != null ? category.id.eq(categoryId) : null;
+        if (categoryId == null) {
+            return null;
+        }
+        return categoryId == 0L ? Expressions.asBoolean(true).isTrue() : category.id.eq(categoryId);
     }
 
     public static BooleanExpression recentIdEq(Long recentId) {


### PR DESCRIPTION
## 전체 상품 조회
상품 조회 시 정해진 카테고리별(Outer, Top, Dress, Bottom)로만 조회할 수 있었으나,
카테고리에 상관없이 모든 상품을 조회할 수 있는 **전체 카테고리 조회 기능**을 구현했습니다.
기존 카테고리 대분류 `categoryId`는 `1`번부터 시작하고, 전체 카테고리의 `categoryId`는 `0`으로 고정했습니다.
- API URI : `/api/v1/category/{categoryId}/{gender}/{filterId}`
- [feat: 전체 상품 조회 기능 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/81e59f05b9e0282d14adee04e8d0d137f255b2d3)