### PR TITLE
예외 처리 : JWT 필터 구현 및 설정

### DIFF
--- a/src/main/java/fittering/mall/config/AcceptedUrl.java
+++ b/src/main/java/fittering/mall/config/AcceptedUrl.java
@@ -1,0 +1,14 @@
+package fittering.mall.config;
+
+import java.util.List;
+
+public class AcceptedUrl {
+    public final static List<String> ACCEPTED_URL_LIST = List.of(
+            "/login", "/signup", "/error",
+            "/api/v1/login", "/api/v1/signup",
+            "/swagger-ui.html", "/swagger-ui/index.html", "/swagger-ui/index.css", "/swagger-ui/swagger-ui.css",
+            "/swagger-ui/swagger-ui-bundle.js", "/swagger-ui/swagger-ui-standalone-preset.js", "/swagger-ui/swagger-initializer.js",
+            "/swagger-ui/favicon-32x32.png", "/swagger-ui/favicon-16x16.png", "/api-docs/json/swagger-config",
+            "/api-docs/json", "/actuator/prometheus"
+    );
+}

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package fittering.mall.config;
 
 import fittering.mall.config.jwt.JwtAuthenticationFilter;
+import fittering.mall.config.jwt.JwtExceptionFilter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -14,7 +15,6 @@ import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
-import fittering.mall.config.jwt.JwtTokenProvider;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsUtils;
 
@@ -25,7 +25,8 @@ import org.springframework.web.cors.CorsUtils;
 public class SecurityConfig {
 
     private final UserDetailsService userDetailsService;
-    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final JwtExceptionFilter jwtExceptionFilter;
 
     @Bean
     SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -45,7 +46,8 @@ public class SecurityConfig {
                                 .anyRequest().hasRole("USER")
 //                                .anyRequest().permitAll()
                 )
-                .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
+                .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class);
         return http.build();
     }
 

--- a/src/main/java/fittering/mall/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtAuthenticationFilter.java
@@ -8,10 +8,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
 
+@Component
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends GenericFilterBean {
 

--- a/src/main/java/fittering/mall/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtAuthenticationFilter.java
@@ -1,5 +1,6 @@
 package fittering.mall.config.jwt;
 
+import fittering.mall.config.AcceptedUrl;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.ServletRequest;
@@ -8,10 +9,12 @@ import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.GenericFilterBean;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -25,7 +28,21 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         //헤더에서 토큰 가져오기
         String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
 
-        if (token != null && jwtTokenProvider.validateToken(token)) {
+        if (token == null) {
+            String requestURI = ((HttpServletRequest) request).getRequestURI();
+            List<String> acceptedUrls = AcceptedUrl.ACCEPTED_URL_LIST;
+
+            for (String acceptedUrl : acceptedUrls) {
+                if (requestURI.equals(acceptedUrl)) {
+                    chain.doFilter(request, response);
+                    return;
+                }
+            }
+
+            throw new JwtException("토큰이 빈 값입니다.");
+        }
+
+        if (jwtTokenProvider.validateToken(token)) {
             Authentication authentication = jwtTokenProvider.getAuthentication(token); //유저 정보
             SecurityContextHolder.getContext().setAuthentication(authentication); //SecurityContext에 객체 저장
         }

--- a/src/main/java/fittering/mall/config/jwt/JwtErrorResponse.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtErrorResponse.java
@@ -1,0 +1,19 @@
+package fittering.mall.config.jwt;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class JwtErrorResponse {
+    private LocalDateTime timestamp;
+    private int status;
+    private String error;
+    private String path;
+}

--- a/src/main/java/fittering/mall/config/jwt/JwtExceptionFilter.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtExceptionFilter.java
@@ -1,0 +1,49 @@
+package fittering.mall.config.jwt;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.oauth2.jwt.JwtException;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.time.LocalDateTime;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class JwtExceptionFilter extends OncePerRequestFilter {
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain)
+            throws ServletException, IOException {
+        try {
+            chain.doFilter(request, response);
+        } catch (JwtException ex) {
+            setResponse(request.getRequestURI(), response, HttpStatus.UNAUTHORIZED, ex);
+        }
+    }
+
+    private void setResponse(String path, HttpServletResponse response, HttpStatus status, Throwable ex) throws RuntimeException, IOException {
+        JwtErrorResponse errorResponse = JwtErrorResponse.builder()
+                .timestamp(LocalDateTime.now())
+                .status(status.value())
+                .error(ex.getMessage())
+                .path(path)
+                .build();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        String jsonResponse = objectMapper.writeValueAsString(errorResponse);
+
+        response.setStatus(status.value());
+        response.setContentType("application/json;charset=UTF-8");
+        response.getWriter().print(jsonResponse);
+    }
+}

--- a/src/main/java/fittering/mall/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtTokenProvider.java
@@ -60,11 +60,11 @@ public class JwtTokenProvider {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
             return !claims.getBody().getExpiration().before(new Date());
         } catch (SignatureException e) {
-            throw new org.springframework.security.oauth2.jwt.JwtException("SignatureException");
+            throw new JwtException("SignatureException");
         } catch (MalformedJwtException e) {
-            throw new org.springframework.security.oauth2.jwt.JwtException("MalformedJwtException");
+            throw new JwtException("MalformedJwtException");
         } catch (ExpiredJwtException e) {
-            throw new org.springframework.security.oauth2.jwt.JwtException("ExpiredJwtException");
+            throw new JwtException("ExpiredJwtException");
         } catch (IllegalArgumentException e) {
             throw new JwtException("IllegalArgumentException");
         }

--- a/src/main/java/fittering/mall/config/jwt/JwtTokenProvider.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtTokenProvider.java
@@ -1,9 +1,6 @@
 package fittering.mall.config.jwt;
 
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jws;
-import io.jsonwebtoken.Jwts;
-import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.*;
 import jakarta.annotation.PostConstruct;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
@@ -11,6 +8,7 @@ import org.springframework.security.authentication.UsernamePasswordAuthenticatio
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.oauth2.jwt.JwtException;
 import org.springframework.stereotype.Component;
 
 import java.util.Base64;
@@ -61,8 +59,14 @@ public class JwtTokenProvider {
         try {
             Jws<Claims> claims = Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token);
             return !claims.getBody().getExpiration().before(new Date());
-        } catch (Exception e) {
-            return false;
+        } catch (SignatureException e) {
+            throw new org.springframework.security.oauth2.jwt.JwtException("SignatureException");
+        } catch (MalformedJwtException e) {
+            throw new org.springframework.security.oauth2.jwt.JwtException("MalformedJwtException");
+        } catch (ExpiredJwtException e) {
+            throw new org.springframework.security.oauth2.jwt.JwtException("ExpiredJwtException");
+        } catch (IllegalArgumentException e) {
+            throw new JwtException("IllegalArgumentException");
         }
     }
 


### PR DESCRIPTION
## JWT 예외처리 필터
### 문제 상황
Fittering 서비스는 헤더 필드 `Authorization` JWT를 확인해 유효한 값인지 검증하는 과정을 통해 권한을 체크합니다.
테스트 중 가장 빈번하게 발생하는 토큰 이슈로는 값이 `null`이거나 유효 시간이 지나 만료됐을 때 2가지가 있었고,
이 때 응답코드는 `401 Unauthorized`가 도착해야 정상인데 **`403 Forbidden`으로 표시되는 문제**가 있었습니다.

### 구현
JWT 토큰 인증 필터 `JwtAuthenticationFilter` 이전에 **토큰 예외 처리 필터 `JwtExceptionFilter`를 두어서**
`JwtAuthenticationFilter`에서 발생하는 JWT 예외 `JwtException`를 `JwtExceptionFilter`에서 처리하도록 설정했습니다.
토큰 만료 예외 `ExpiredJwtException`는 여기서 처리하는 예외에 포함됩니다.
```java
@Bean
SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
    ...
    http
            .authorizeHttpRequests((authorizeHttpRequests) -> ...) //허용 URL 생략
            .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
            .addFilterBefore(jwtExceptionFilter, JwtAuthenticationFilter.class); //JWT 예외 처리 필터 추가
    return http.build();
}
```
- [feat: JWT 예외 필터 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/899672f0c45f79181434e448eb74bfdf2da30f59)
- [feat: JWT 예외 필터 적용](https://github.com/YeolJyeongKong/fittering-BE/commit/64d7aeb49d3369503b0499e30a0332c24e34dd30)

### null 처리
토큰이 `null`인 경우 토큰이 필요하지 않은 즉, 권한이 필요없는 API 혹은 사이트 접근 시 토큰 검증을 하지 않도록
Spring Security 설정 클래스 `SecurityConfig`에서 `permitAll()`로 허용해주고 있었으나 `JwtAuthenticationFilter`에서
**토큰이 `null`일 때 들어오는 모든 요청에 대해 불필요하게 검증을 시도하는 문제가 있었습니다.**

때문에 `AcceptedUrl`을 정의해 `permitAll()`로 적용되는 모든 URL을 저장해주고 `JwtAuthenticationFilter`에서
`AcceptedUrl`에 저장된 URL로 들어오는 요청은 토큰 검증을 하지 않도록 설정해 문제를 해결할 수 있었습니다.
해당되지 않은 URL이면 토큰이 `null`이지만 권한이 필요한 요청을 발생한 것이므로 `JwtException`을 throw 하도록 설정했습니다.
```java
@Override
public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
        throws IOException, ServletException {
    String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);

    if (token == null) {
        String requestURI = ((HttpServletRequest) request).getRequestURI();
        List<String> acceptedUrls = AcceptedUrl.ACCEPTED_URL_LIST;

        for (String acceptedUrl : acceptedUrls) {
            //허용 URL이면 토큰 검증하지 않기
            if (requestURI.equals(acceptedUrl)) {
                chain.doFilter(request, response);
                return;
            }
        }

        throw new JwtException("토큰이 빈 값입니다.");
    }
    ...
}
```
- 📄 : [[Spring] JWT 예외 처리 필터 설정하기](https://yooniversal.github.io/project/post256/)
- [feat: 권한 제한없는 URL 모음 클래스 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/f776faa21f12e99e6aaf69b768093aac42e298c2)
- [feat: JWT 예외 발생 시 필터로 처리하도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/ad058b985c0ad8483d694fa6558dec784e04c7ac)