### PR TITLE
버그 수정 : OAuth 인증, 필터링

### DIFF
--- a/src/main/java/fittering/mall/config/AcceptedUrl.java
+++ b/src/main/java/fittering/mall/config/AcceptedUrl.java
@@ -9,6 +9,7 @@ public class AcceptedUrl {
             "/swagger-ui.html", "/swagger-ui/index.html", "/swagger-ui/index.css", "/swagger-ui/swagger-ui.css",
             "/swagger-ui/swagger-ui-bundle.js", "/swagger-ui/swagger-ui-standalone-preset.js", "/swagger-ui/swagger-initializer.js",
             "/swagger-ui/favicon-32x32.png", "/swagger-ui/favicon-16x16.png", "/api-docs/json/swagger-config",
-            "/api-docs/json", "/actuator/prometheus"
+            "/api-docs/json", "/actuator/prometheus",
+            "/login/oauth/google", "login/oauth/kakao"
     );
 }

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/login", "/api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()
+                                .requestMatchers("/login/oauth/google", "login/oauth/kakao").permitAll()
                                 .anyRequest().hasRole("USER")
 //                                .anyRequest().permitAll()
                 )

--- a/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
+++ b/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
@@ -73,10 +73,10 @@ public class EqualMethod {
      * else     : 성별 무관
      */
     public static BooleanExpression genderEq(String gender) {
-        if(gender.equals(MALE) || gender.equals(FEMALE)) {
-            return product.gender.eq(gender);
+        if (!gender.equals(MALE) && !gender.equals(FEMALE)) {
+            return Expressions.asBoolean(true).isTrue();
         }
-        return Expressions.asBoolean(true).isTrue();
+        return product.gender.eq(gender);
     }
 
     public static BooleanExpression productNameContains(String productName) {

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -35,7 +35,7 @@ import static fittering.mall.repository.querydsl.EqualMethod.*;
 
 public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
-    private static final int INDEX_ASC = 0;
+    private static final int INDEX_DESC = 0;
     private static final int VIEW_DESC = 1;
     private static final int PRICE_ASC = 2;
     private static final int MOST_POPULAR_TARGET_COUNT = 1;
@@ -582,13 +582,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     public OrderSpecifier<? extends Number> filter(Long filterId) {
-        if(filterId == INDEX_ASC) {
-            return product.id.asc();
+        if (filterId == INDEX_DESC) {
+            return product.id.desc();
         }
-        if(filterId == VIEW_DESC) {
+        if (filterId == VIEW_DESC) {
             return product.view.desc();
         }
-        if(filterId == PRICE_ASC) {
+        if (filterId == PRICE_ASC) {
             return product.price.asc();
         }
         return product.price.desc();


### PR DESCRIPTION
## 버그 수정
### OAuth 인증
구글/카카오 소셜 로그인 시 각 서버에서 지원하는 인증 URI로 redirect 되도록 내부적으로 구현돼 있었습니다.
해당 URI로 이동하려면 Spring Security 설정 클래스 `SecurityConfig`에서 **접근 가능하도록 별도로 설정을 해줘야 했으나**
이전에 OAuth 구현한 내용을 반영하는 과정(#48)에서 누락된 것으로 확인했습니다. `permitAll()`로 다음 경로에 설정해서 해결했습니다.
- 구글 : `/login/oauth/google`
- 카카오 : `login/oauth/kakao`
- [fix: 권한없어도 OAuth 인증 URI 접근할 수 있도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/28bb6386611db68525c04cf0e03280f24cb498a3)

### 최신순 정렬
상품이 최신순으로 표시되려면 인덱스가 큰 순 즉, 오래된순으로 정렬해야 합니다.
반대로 설정돼 있어 수정했습니다.
- [fix: 최신순 정렬이 안되는 문제 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/d88df912d8699f18e77c88cff48c26a4ddd9c488)

### 성별 필터링
성별이 `A`인 경우 남녀 공용으로 `M`, `F`로 검색할 때에도 조회할 수 있어야 하는데 **`A`로 설정된 상품은 조회가 안되는 문제가 있었습니다.**
조건을 잘못 걸어서 발생한 문제임을 확인했고 순서를 바꿔주면서 해결했습니다.
- [fix: 성별 필터링 버그 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/c97ba57f9ed3be6319f0a57334135fd848e6f855)