### PR TITLE
리팩토링 : API, Querydsl

### DIFF
--- a/src/main/java/fittering/mall/controller/CategoryController.java
+++ b/src/main/java/fittering/mall/controller/CategoryController.java
@@ -22,7 +22,7 @@ public class CategoryController {
 
     @Operation(summary = "카테고리 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"카테고리 등록 완료\"")))
-    @PostMapping("/category/{categoryName}")
+    @PostMapping("/categories/{categoryName}")
     public ResponseEntity<?> save(@PathVariable("categoryName") String categoryName) {
         categoryService.save(categoryName);
         return new ResponseEntity<>("카테고리 등록 완료", HttpStatus.OK);
@@ -30,7 +30,7 @@ public class CategoryController {
 
     @Operation(summary = "세부 카테고리 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"카테고리 등록 완료\"")))
-    @PostMapping("/category/sub/{categoryName}/{subCategoryName}")
+    @PostMapping("/categories/sub/{categoryName}/{subCategoryName}")
     public ResponseEntity<?> saveSubCategory(@PathVariable("categoryName") String categoryName,
                                              @PathVariable("subCategoryName") String subCategoryName) {
         categoryService.saveSubCategory(categoryName, subCategoryName);

--- a/src/main/java/fittering/mall/controller/MailController.java
+++ b/src/main/java/fittering/mall/controller/MailController.java
@@ -29,7 +29,7 @@ public class MailController {
             @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"이메일을 사용하는 유저가 존재합니다.\""))),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"일치하는 메일이 없습니다.\"")))
     })
-    @PostMapping("/check/email")
+    @PostMapping("/email/check")
     public ResponseEntity<?> checkEmail(@RequestParam("email") String email) {
         if(!userService.emailExist(email)) {
             return new ResponseEntity<>("일치하는 메일이 없습니다.", HttpStatus.BAD_REQUEST);
@@ -42,7 +42,7 @@ public class MailController {
             @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"비밀번호 발급이 완료되었습니다.\""))),
             @ApiResponse(responseCode = "400", description = "BAD REQUEST", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"비밀번호 찾기는 1시간에 한 번 가능합니다.\"")))
     })
-    @PostMapping("/send/password")
+    @PostMapping("/password/send")
     public ResponseEntity<?> sendPassword(@RequestParam("email") String email) {
         if(!userService.updatePasswordToken(email)) {
             return new ResponseEntity<>("비밀번호 찾기는 1시간에 한 번 가능합니다.", HttpStatus.BAD_REQUEST);

--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -44,7 +44,7 @@ public class ProductController {
 
     @Operation(summary = "상품 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"상품 등록 완료\"")))
-    @PostMapping("/product")
+    @PostMapping("/products")
     public ResponseEntity<?> save(@RequestBody RequestProductDetailDto requestProductDto) {
         Category category = categoryService.findByName(requestProductDto.getCategoryName());
         SubCategory subCategory = categoryService.findByNameOfSubCategory(requestProductDto.getSubCategoryName());
@@ -74,7 +74,7 @@ public class ProductController {
 
     @Operation(summary = "카테고리별 상품 조회 (대분류)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/category/{categoryId}/{gender}/{filterId}")
+    @GetMapping("/categories/{categoryId}/{gender}/{filterId}")
     public ResponseEntity<?> productWithCategory(@PathVariable("categoryId") Long categoryId,
                                                  @PathVariable("gender") String gender,
                                                  @PathVariable("filterId") Long filterId,
@@ -85,7 +85,7 @@ public class ProductController {
 
     @Operation(summary = "카테고리별 상품 조회 (소분류)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/category/sub/{subCategoryId}/{gender}/{filterId}")
+    @GetMapping("/categories/sub/{subCategoryId}/{gender}/{filterId}")
     public ResponseEntity<?> productWithSubCategory(@PathVariable("subCategoryId") Long subCategoryId,
                                                     @PathVariable("gender") String gender,
                                                     @PathVariable("filterId") Long filterId,
@@ -96,7 +96,7 @@ public class ProductController {
 
     @Operation(summary = "카테고리별 상품 개수 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductCategoryDto.class))))
-    @GetMapping("/category/count")
+    @GetMapping("/categories/count")
     public ResponseEntity<?> multipleProductCountWithCategory() {
         List<ResponseProductCategoryDto> categoryWithProductCounts = productService.multipleProductCountWithCategory();
         return new ResponseEntity<>(categoryWithProductCounts, HttpStatus.OK);
@@ -132,7 +132,7 @@ public class ProductController {
 
     @Operation(summary = "쇼핑몰 내 카테고리별 상품 개수 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductCategoryDto.class))))
-    @GetMapping("/malls/{mallId}/category/count")
+    @GetMapping("/malls/{mallId}/categories/count")
     public ResponseEntity<?> productCountWithCategoryOfMall(@PathVariable("mallId") Long mallId) {
         List<ResponseProductCategoryDto> categoryWithProductCounts = productService.productCountWithCategoryOfMall(mallId);
         return new ResponseEntity<>(categoryWithProductCounts, HttpStatus.OK);
@@ -152,7 +152,7 @@ public class ProductController {
             @Content(schema = @Schema(implementation = ResponseDressDto.class)),
             @Content(schema = @Schema(implementation = ResponseBottomDto.class))
     })
-    @GetMapping("/product/{productId}")
+    @GetMapping("/products/{productId}")
     public ResponseEntity<?> productDetail(@PathVariable("productId") Long productId,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
         Product product = productService.findById(productId);

--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -45,7 +45,7 @@ public class UserController {
 
     @Operation(summary = "마이페이지 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseUserDto.class)))
-    @GetMapping("/user/mypage")
+    @GetMapping("/users/mypage")
     public ResponseEntity<?> edit(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         ResponseUserDto userInfo = userService.info(principalDetails.getUser().getId());
         return new ResponseEntity<>(userInfo, HttpStatus.OK);
@@ -53,7 +53,7 @@ public class UserController {
 
     @Operation(summary = "마이페이지 수정")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = RequestUserDto.class)))
-    @PostMapping("/user/mypage")
+    @PostMapping("/users/mypage")
     public ResponseEntity<?> edit(@RequestBody RequestUserDto requestUserDto,
                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
         userService.infoUpdate(requestUserDto, principalDetails.getUser().getId());
@@ -65,7 +65,7 @@ public class UserController {
             @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"비밀번호 변경 성공\""))),
             @ApiResponse(responseCode = "401", description = "FAIL", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"현재 비밀번호 인증 실패\"")))
     })
-    @PostMapping("/user/check/password/{password}/{newPassword}")
+    @PostMapping("/users/password/check/{password}/{newPassword}")
     public ResponseEntity<?> checkPassword(@PathVariable("password") String password,
                                            @PathVariable("newPassword") String newPassword,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -79,7 +79,7 @@ public class UserController {
 
     @Operation(summary = "체형 정보 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMeasurementDto.class)))
-    @GetMapping("/user/mysize")
+    @GetMapping("/users/mysize")
     public ResponseEntity<?> measurementEdit(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         ResponseMeasurementDto measurement = userService.measurementInfo(principalDetails.getUser().getId());
         return new ResponseEntity<>(measurement, HttpStatus.OK);
@@ -87,7 +87,7 @@ public class UserController {
 
     @Operation(summary = "체형 정보 수정")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = MeasurementDto.class)))
-    @PostMapping("/user/mysize")
+    @PostMapping("/users/mysize")
     public ResponseEntity<?> measurementEdit(@RequestBody RequestMeasurementDto requestMeasurementDto,
                                              @AuthenticationPrincipal PrincipalDetails principalDetails) {
         MeasurementDto measurementDto = MeasurementMapper.INSTANCE.toMeasurementDto(requestMeasurementDto);
@@ -97,7 +97,7 @@ public class UserController {
 
     @Operation(summary = "유저 즐겨찾기 상품 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/favorite_goods")
+    @GetMapping("/users/favorite_goods")
     public ResponseEntity<?> favoriteProduct(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                              Pageable pageable) {
         Page<ResponseProductPreviewDto> products = favoriteService.userFavoriteProduct(
@@ -107,7 +107,7 @@ public class UserController {
 
     @Operation(summary = "유저 즐겨찾기 상품 조회 (미리보기)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/favorite_goods/preview")
+    @GetMapping("/users/favorite_goods/preview")
     public ResponseEntity<?> favoriteProductPreview(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ResponseProductPreviewDto> products = favoriteService.userFavoriteProductPreview(principalDetails.getUser().getId());
         return new ResponseEntity<>(products, HttpStatus.OK);
@@ -115,7 +115,7 @@ public class UserController {
 
     @Operation(summary = "유저 즐겨찾기 상품 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"유저 즐겨찾기 상품 등록 완료\"")))
-    @PostMapping("/user/favorite_goods/{productId}")
+    @PostMapping("/users/favorite_goods/{productId}")
     public ResponseEntity<?> saveFavoriteProduct(@PathVariable("productId") Long productId,
                                                  @AuthenticationPrincipal PrincipalDetails principalDetails) {
         favoriteService.saveFavoriteProduct(principalDetails.getUser().getId(), productId);
@@ -124,7 +124,7 @@ public class UserController {
 
     @Operation(summary = "유저 즐겨찾기 상품 삭제")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"유저 즐겨찾기 상품 삭제 완료\"")))
-    @DeleteMapping("/user/favorite_goods/{productId}")
+    @DeleteMapping("/users/favorite_goods/{productId}")
     public ResponseEntity<?> deleteFavoriteProduct(@PathVariable("productId") Long productId,
                                                    @AuthenticationPrincipal PrincipalDetails principalDetails) {
         favoriteService.deleteFavoriteProduct(principalDetails.getUser().getId(), productId);
@@ -133,7 +133,7 @@ public class UserController {
 
     @Operation(summary = "유저 최근 본 상품 조회 (미리보기)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/recent/preview")
+    @GetMapping("/users/recent/preview")
     public ResponseEntity<?> recentProductPreview(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ResponseProductPreviewDto> products = userService.recentProductPreview(principalDetails.getUser().getId());
         return new ResponseEntity<>(products, HttpStatus.OK);
@@ -141,7 +141,7 @@ public class UserController {
 
     @Operation(summary = "유저 최근 본 상품 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/recent")
+    @GetMapping("/users/recent")
     public ResponseEntity<?> recentProduct(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                            Pageable pageable) {
         Page<ResponseProductPreviewDto> products = userService.recentProduct(principalDetails.getUser().getId(), pageable);
@@ -150,7 +150,7 @@ public class UserController {
 
     @Operation(summary = "체형 스마트 분석")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMeasurementDto.class))))
-    @PostMapping("/user/recommendation/measurement")
+    @PostMapping("/users/recommendation/measurement")
     public ResponseEntity<?> recommendMeasurement(@RequestBody RequestSmartMeasurementDto requestSmartMeasurementDto,
                                                   @AuthenticationPrincipal PrincipalDetails principalDetails) {
         //request: smartMeasurementDto
@@ -173,7 +173,7 @@ public class UserController {
      */
     @Operation(summary = "추천 상품 조회 (미리보기)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/recommendation/preview")
+    @GetMapping("/users/recommendation/preview")
     public ResponseEntity<?> recommendProductPreview(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<Long> productIds = findRecommendedProductIds(principalDetails.getUser().getId());
         List<ResponseProductPreviewDto> products = productService.recommendProduct(productIds, true);
@@ -182,7 +182,7 @@ public class UserController {
 
     @Operation(summary = "추천 상품 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/recommendation")
+    @GetMapping("/users/recommendation")
     public ResponseEntity<?> recommendProduct(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<Long> productIds = findRecommendedProductIds(principalDetails.getUser().getId());
         List<ResponseProductPreviewDto> products = productService.recommendProduct(productIds, false);
@@ -228,7 +228,7 @@ public class UserController {
      */
     @Operation(summary = "비슷한 체형 고객 pick 조회 (미리보기)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/recommendation/pick/preview")
+    @GetMapping("/users/recommendation/pick/preview")
     public ResponseEntity<?> recommendProductPreviewOnPick(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<Long> productIds = findRecommendedProductIdsOnPick(principalDetails.getUser().getId());
         List<ResponseProductPreviewDto> products = productService.recommendProduct(productIds, true);
@@ -237,7 +237,7 @@ public class UserController {
 
     @Operation(summary = "비슷한 체형 고객 pick 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/user/recommendation/pick")
+    @GetMapping("/users/recommendation/pick")
     public ResponseEntity<?> recommendProductOnPick(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<Long> productIds = findRecommendedProductIdsOnPick(principalDetails.getUser().getId());
         List<ResponseProductPreviewDto> products = productService.recommendProduct(productIds, false);
@@ -277,7 +277,7 @@ public class UserController {
 
     @Operation(summary = "유저 즐겨찾기 쇼핑몰 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"즐겨찾기 등록 완료\"")))
-    @PostMapping("/favorite/{mallId}")
+    @PostMapping("/favorites/{mallId}")
     public ResponseEntity<?> setFavoriteMall(@PathVariable("mallId") Long mallId,
                                              @AuthenticationPrincipal PrincipalDetails principalDetails) {
         favoriteService.saveFavoriteMall(principalDetails.getUser().getId(), mallId);
@@ -286,7 +286,7 @@ public class UserController {
 
     @Operation(summary = "유저 즐겨찾기 쇼핑몰 삭제")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"즐겨찾기 삭제 완료\"")))
-    @DeleteMapping("/favorite/{mallId}")
+    @DeleteMapping("/favorites/{mallId}")
     public ResponseEntity<?> deleteFavoriteMall(@PathVariable("mallId") Long mallId,
                                                 @AuthenticationPrincipal PrincipalDetails principalDetails) {
         favoriteService.deleteFavoriteMall(principalDetails.getUser().getId(), mallId);

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -280,7 +280,6 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         Product productInfo = queryFactory
                 .selectFrom(product)
-                .from(product)
                 .leftJoin(product.mall, mall)
                 .leftJoin(product.category, category)
                 .leftJoin(product.sizes, size)
@@ -339,7 +338,6 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         Product productInfo = queryFactory
                 .selectFrom(product)
-                .from(product)
                 .leftJoin(product.mall, mall)
                 .leftJoin(product.category, category)
                 .leftJoin(product.sizes, size)
@@ -398,7 +396,6 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         Product productInfo = queryFactory
                 .selectFrom(product)
-                .from(product)
                 .leftJoin(product.mall, mall)
                 .leftJoin(product.category, category)
                 .leftJoin(product.sizes, size)
@@ -475,7 +472,6 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
         Product productInfo = queryFactory
                 .selectFrom(product)
-                .from(product)
                 .leftJoin(product.mall, mall)
                 .leftJoin(product.category, category)
                 .leftJoin(product.sizes, size)


### PR DESCRIPTION
## 리팩토링
### API URI
`/check/email`, `/send/password` 등 URI에서 도메인이 뒤에 있어 **어떤 곳에서 처리되는지 파악하기 어려운 문제**가 있었습니다.
`email`, `password` 등의 도메인이 앞쪽에 오도록 배치했습니다.
- [refactor: 도메인이 앞으로 오도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/482340e377b125d010fd21f332d73e30d175b2ab)

`product`, `user`, `favorite` 등의 도메인이 URI에서 단수형으로 표시되고 있어 모두 **복수형**으로 수정했습니다.
- [refactor: URI 도메인 복수형으로 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/d79d1e6de8c5949c3ebf56f928d212f76df2c9c7)

### Querydsl 쿼리 수정
`selectFrom()`절을 적용해 `from()`을 적용하지 않아도 되는 쿼리였으나 추가돼있는 로직이 있었습니다.
상품 상세 조회 로직에서 사용되고 있었고, `from()`절을 제거했습니다.
```java
public TopProductDto topProductDetail(Long productId) {
    ...
    Product productInfo = queryFactory
            .selectFrom(product)
            //.from(product) 제거
            .leftJoin(product.mall, mall)
    ...
}
```
- [refactor: 쓸모없는 쿼리 제거](https://github.com/YeolJyeongKong/fittering-BE/commit/94bc5d25a120ea01b32b76fe1a746b44031a37de)