### PR TITLE
API 구현 : 애플 OAuth 인증 URI 연결

### DIFF
--- a/src/main/java/fittering/mall/config/AcceptedUrl.java
+++ b/src/main/java/fittering/mall/config/AcceptedUrl.java
@@ -10,6 +10,6 @@ public class AcceptedUrl {
             "/swagger-ui/swagger-ui-bundle.js", "/swagger-ui/swagger-ui-standalone-preset.js", "/swagger-ui/swagger-initializer.js",
             "/swagger-ui/favicon-32x32.png", "/swagger-ui/favicon-16x16.png", "/api-docs/json/swagger-config",
             "/api-docs/json", "/actuator/prometheus",
-            "/login/oauth/apple", "/login/oauth/google", "login/oauth/kakao"
+            "/login/oauth/apple", "/login/oauth/google", "/login/oauth/kakao"
     );
 }

--- a/src/main/java/fittering/mall/config/AcceptedUrl.java
+++ b/src/main/java/fittering/mall/config/AcceptedUrl.java
@@ -10,6 +10,6 @@ public class AcceptedUrl {
             "/swagger-ui/swagger-ui-bundle.js", "/swagger-ui/swagger-ui-standalone-preset.js", "/swagger-ui/swagger-initializer.js",
             "/swagger-ui/favicon-32x32.png", "/swagger-ui/favicon-16x16.png", "/api-docs/json/swagger-config",
             "/api-docs/json", "/actuator/prometheus",
-            "/login/oauth/google", "login/oauth/kakao"
+            "/login/oauth/apple", "/login/oauth/google", "login/oauth/kakao"
     );
 }

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -43,7 +43,7 @@ public class SecurityConfig {
                                 .requestMatchers("/api/v1/login", "/api/v1/signup").permitAll()
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()
-                                .requestMatchers("/login/oauth/google", "login/oauth/kakao").permitAll()
+                                .requestMatchers("/login/oauth/apple", "/login/oauth/google", "login/oauth/kakao").permitAll()
                                 .anyRequest().hasRole("USER")
 //                                .anyRequest().permitAll()
                 )

--- a/src/main/java/fittering/mall/controller/OAuthController.java
+++ b/src/main/java/fittering/mall/controller/OAuthController.java
@@ -29,6 +29,15 @@ public class OAuthController {
     private final UserService userService;
     private final JwtTokenProvider jwtTokenProvider;
 
+    @Value("${apple.client-id}")
+    private String APPLE_CLIENT_ID;
+    @Value("${apple.redirect-uri}")
+    private String APPLE_REDIRECT_URI;
+    @Value("${apple.response_type}")
+    private String APPLE_RESPONSE_TYPE;
+    @Value("${apple.nonce}")
+    private String APPLE_NONCE;
+
     @Value("${kakao.client-id}")
     private String KAKAO_CLIENT_ID;
     @Value("${kakao.client-secret}")
@@ -56,10 +65,20 @@ public class OAuthController {
     private String GOOGLE_GRANT_TYPE;
 
     private final String MAIN_LOGIN_URL = "https://fit-tering.com/login";
+    private final String APPLE_AUTH_URL = "https://appleid.apple.com/auth/authorize";
     private final String KAKAO_AUTH_URL = "https://kauth.kakao.com/oauth/authorize";
     private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
     private final String GOOGLE_AUTH_URL = "https://accounts.google.com/o/oauth2/v2/auth";
     private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+
+    @GetMapping("/login/oauth/apple")
+    public String loginAppleOAuth() {
+        return "redirect:" + APPLE_AUTH_URL
+                + "?client_id=" + APPLE_CLIENT_ID
+                + "&redirect_uri=" + APPLE_REDIRECT_URI
+                + "&response_type=" + APPLE_RESPONSE_TYPE
+                + "&nonce=" + APPLE_NONCE;
+    }
 
     @PostMapping("/login/apple")
     public String appleServiceRedirect(AppleServiceResponse appleServiceResponse) {


### PR DESCRIPTION
### 애플 OAuth
프론트에서 애플 소셜 로그인 버튼을 구현할 때 버튼 내에 `clientId`, `redirectURI` 등의 중요 정보를 넣어 초기화하는 방식으로 하려고 
했으나, 이 방식의 경우 **노출될 가능성이 있기 때문에** 백엔드에서 애플 인증 URI로 redirect 할 수 있는 API를 만들어서 제공하는 방식으로 
수정했습니다. 중요 정보들은 `application.yml`에서 가져오도록 설정했습니다.
```java
@Value("${apple.client-id}")
private String APPLE_CLIENT_ID;
@Value("${apple.redirect-uri}")
private String APPLE_REDIRECT_URI;
@Value("${apple.response_type}")
private String APPLE_RESPONSE_TYPE;
@Value("${apple.nonce}")
private String APPLE_NONCE;
```
redirect 되는 인증 URI는 `https://appleid.apple.com/auth/authorize`로 설정했습니다.
- API URI : `/login/oauth/apple`
- [feat: apple 로그인 API 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/b8e5f4fd844433a5dffe603a0b01e432eb42026c)
- [feat: apple API URI 접근 허용 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/40d0be71e9e24e5727293974a00e7475119070f9)