### PR TITLE
버그 수정 : OAuth 로그인

### DIFF
--- a/src/main/java/fittering/mall/config/AcceptedUrl.java
+++ b/src/main/java/fittering/mall/config/AcceptedUrl.java
@@ -10,6 +10,7 @@ public class AcceptedUrl {
             "/swagger-ui/swagger-ui-bundle.js", "/swagger-ui/swagger-ui-standalone-preset.js", "/swagger-ui/swagger-initializer.js",
             "/swagger-ui/favicon-32x32.png", "/swagger-ui/favicon-16x16.png", "/api-docs/json/swagger-config",
             "/api-docs/json", "/actuator/prometheus",
-            "/login/oauth/apple", "/login/oauth/google", "/login/oauth/kakao"
+            "/login/oauth/apple", "/login/oauth/google", "/login/oauth/kakao",
+            "/login/apple", "/login/google", "/login/kakao"
     );
 }

--- a/src/main/java/fittering/mall/config/SecurityConfig.java
+++ b/src/main/java/fittering/mall/config/SecurityConfig.java
@@ -44,6 +44,7 @@ public class SecurityConfig {
                                 .requestMatchers("/swagger-ui.html", "/swagger-ui/**", "/api-docs/**").permitAll()
                                 .requestMatchers("/actuator/prometheus/**").permitAll()
                                 .requestMatchers("/login/oauth/apple", "/login/oauth/google", "login/oauth/kakao").permitAll()
+                                .requestMatchers("/login/apple", "/login/google", "/login/kakao").permitAll()
                                 .anyRequest().hasRole("USER")
 //                                .anyRequest().permitAll()
                 )

--- a/src/main/java/fittering/mall/controller/OAuthController.java
+++ b/src/main/java/fittering/mall/controller/OAuthController.java
@@ -13,7 +13,6 @@ import org.springframework.stereotype.Controller;
 import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
@@ -80,7 +79,7 @@ public class OAuthController {
                 + "&nonce=" + APPLE_NONCE;
     }
 
-    @PostMapping("/login/apple")
+    @GetMapping("/login/apple")
     public String appleServiceRedirect(AppleServiceResponse appleServiceResponse) {
         if (appleServiceResponse == null) {
             return "redirect:" + MAIN_LOGIN_URL;

--- a/src/main/java/fittering/mall/service/OAuthService.java
+++ b/src/main/java/fittering/mall/service/OAuthService.java
@@ -41,7 +41,7 @@ public class OAuthService {
                 .ageRange(getAgeRange(DEFAULT_YEAR, DEFAULT_MONTH, DEFAULT_DAY))
                 .provider(provider)
                 .measurement(measurement)
-                .roles(new ArrayList<>(List.of("USER")))
+                .roles(new ArrayList<>(List.of("ROLE_USER")))
                 .build());
     }
 


### PR DESCRIPTION
## OAuth 로그인
### 401 : 토큰 null
소셜 로그인 버튼을 누르고 각 인증 사이트에서 로그인 성공 시 설정해둔 `redirectURI`로 redirect 하게 되는데,  이 `redirectURI`에는 토큰이 없어도 접근할 수 있도록 설정돼야 합니다.

하지만 서버에서 **토큰이 `null`일 때 해당 URI에 대해 요청을 허용하도록 설정이 안돼있어** `401`에러가 발생했고, `SecurityConfig`와 `AcceptedUrl`를 수정해서 해결했습니다.
```java
public class SecurityConfig {
    ...
    @Bean
    SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
        http
                .authorizeHttpRequests((authorizeHttpRequests) ->
                        authorizeHttpRequests
                                ...
                                .requestMatchers("/login/oauth/apple", "/login/oauth/google", "login/oauth/kakao").permitAll()
                                .requestMatchers("/login/apple", "/login/google", "/login/kakao").permitAll() //추가
                                ...
}

public class AcceptedUrl {
    public final static List<String> ACCEPTED_URL_LIST = List.of(
            ...
            "/login/oauth/apple", "/login/oauth/google", "/login/oauth/kakao",
            "/login/apple", "/login/google", "/login/kakao" //추가
    );
}
```
- [fix: OAuth redirectURI 토큰 null 허용 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/f8ca5dee6f557e348f9a3923365e27d8ab3d9000)

### 405 : Method Not Allowed
애플 로그인 요청 시 redirect 되는 URI에 대해 `@PostMapping`로 잘못 설정돼 있어 `@GetMapping`로 수정했습니다.
- [fix: 애플 로그인 시 405 에러 발생하는 문제 해결](https://github.com/YeolJyeongKong/fittering-BE/commit/a04b2472cdcf82a8a959c17062d06173213c20f5)

### 403 : OAuth 회원가입 시 잘못된 권한 저장
소셜 로그인 시 새로 가입된 유저에 대한 권한이 `USER`로 등록돼 있어 `SecurityConfig`에서 **권한 체크를 제대로 못하는 문제**가 있었습니다.
가입 시 권한을 `USER`가 아닌 `ROLE_USER`로 등록했습니다.
- [fix: 소셜 로그인으로 가입한 유저 권한 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/5d69ac6de8aa3c09ad05e41217c4b17856d0772f)