### PR TITLE
버그 수정 : 성별 필터링

### DIFF
--- a/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
+++ b/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
@@ -18,6 +18,7 @@ public class EqualMethod {
 
     private static final String MALE = "M";
     private static final String FEMALE = "F";
+    private static final String ALL_GENDER = "A";
 
     public static BooleanExpression userIdEq(Long userId) {
         return userId != null ? user.id.eq(userId) : null;
@@ -76,7 +77,7 @@ public class EqualMethod {
         if (!gender.equals(MALE) && !gender.equals(FEMALE)) {
             return Expressions.asBoolean(true).isTrue();
         }
-        return product.gender.eq(gender);
+        return product.gender.eq(gender).or(product.gender.eq(ALL_GENDER));
     }
 
     public static BooleanExpression productNameContains(String productName) {


### PR DESCRIPTION
## 버그 수정
### 성별 필터링
남성/여성으로 필터링 했을 때 남녀 공용 상품이 조회되지 않는 문제가 있었습니다.
성별 필터링 함수 `genderEq()`에서 남성 `MALE`, 여성 `FEMALE` 등이 파라미터 `gender`로 들어올 때,
`gender`가 `MALE`, `FEMALE`이 아닌 경우 상품에 등록된 성별 정보와 일치하는지를 체크하도록 설정했는데
이렇게 설정하는 경우 상품이 `MALE`, `FEMALE`이 아닌 **남녀 공용 `ALL_GENDER`일 때 `gender`와 일치하지 않으므로 조회할 수 없습니다.**

상품의 `gender` 값이 남녀 공용 즉, `ALL_GENDER`일 때도 조회할 수 있도록 `or()` 메소드를 사용해 해결했습니다.
```java
public static BooleanExpression genderEq(String gender) {
    if (!gender.equals(MALE) && !gender.equals(FEMALE)) {
        return Expressions.asBoolean(true).isTrue();
    }
    return product.gender.eq(gender).or(product.gender.eq(ALL_GENDER)); //or() 추가
}
```
- [fix: 성별 필터링 버그 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/bb6adf7dbc395695042c767b9f2b487651a7a73c)