### PR TITLE
버그 수정 : 검색 필터, 토큰 사용하지 않는 API

### DIFF
--- a/src/main/java/fittering/mall/config/jwt/JwtAuthenticationFilter.java
+++ b/src/main/java/fittering/mall/config/jwt/JwtAuthenticationFilter.java
@@ -38,7 +38,7 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
                 }
             }
 
-            if (isAuthUrl(requestURI)) {
+            if (isNoAuthUrl(requestURI)) {
                 chain.doFilter(request, response);
                 return;
             }
@@ -55,9 +55,9 @@ public class JwtAuthenticationFilter extends GenericFilterBean {
         chain.doFilter(request, response);
     }
 
-    private static boolean isAuthUrl(String requestURI) {
+    private static boolean isNoAuthUrl(String requestURI) {
         if (requestURI.startsWith(NO_AUTH_URL)) {
-            return requestURI.startsWith(AUTH_URL);
+            return !requestURI.startsWith(AUTH_URL);
         }
         return false;
     }

--- a/src/main/java/fittering/mall/service/SearchService.java
+++ b/src/main/java/fittering/mall/service/SearchService.java
@@ -18,7 +18,7 @@ public class SearchService {
     private final ProductRepository productRepository;
     private final MallRepository mallRepository;
 
-    @Cacheable(value = "Search", key = "#productName + '_' + #gender")
+    @Cacheable(value = "Search", key = "#productName + '_' + #gender + '_' + #filterId")
     public RestPage<ResponseProductPreviewDto> products(String productName, String gender, Long filterId, Pageable pageable) {
         return new RestPage<>(productRepository.searchProduct(productName, gender, filterId, pageable));
     }


### PR DESCRIPTION
## 버그 수정
### 검색 필터
검색 기능을 테스트하던 중 정렬 기능이 정상적으로 동작하지 않는 문제가 있었습니다.
정렬 기능은 `filterId`에 의해 설정되는데, 캐시에 저장되는 key 값에 `filterId`도 포함돼야 했으나 같은 데이터만 응답으로 나가고 있었습니다.
`@Cacheable`에 `filterId`를 추가하면서 해결할 수 있었습니다.
- [fix: 필터링 안되는 버그 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/018049e1802222ef09f92f35c5c1a0cd31063dc7)

### 토큰 사용하지 않는 API
이전에 인증이 되는 API 호출 시 토큰 검증을 하도록 `isAuthUrl()`를 적용했으나(#68) **적절한 위치에 선언하지 읺아 에러가 발생했습니다.**
토큰이 없는 요청일 때 토큰을 사용하지 않는 API를 사용했다면 통과하도록 하고, 그렇지 않은 경우 `JwtException`를 발생하도록 수정했습니다.
토큰을 사용하지 않는 API 경로임을 체크할 땐 `isNoAuthUrl()`를 사용했고, 기존에 사용했던 `isAuthUrl()`는 삭제했습니다.
```java
@Override
public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
        throws IOException, ServletException {
    String token = jwtTokenProvider.resolveToken((HttpServletRequest) request);
    
    //토큰이 없는 요청
    if (token == null) {
        String requestURI = ((HttpServletRequest) request).getRequestURI();
        ...

        //토큰이 필요없는 API에 대한 요청인 경우 통과
        if (isNoAuthUrl(requestURI)) {
            chain.doFilter(request, response);
            return;
        }

        throw new JwtException("토큰이 빈 값입니다.");
    }

    //토큰이 있는 요청
    ...
}

private static boolean isNoAuthUrl(String requestURI) {
    if (requestURI.startsWith(NO_AUTH_URL)) {
        return !requestURI.startsWith(AUTH_URL);
    }
    return false;
}
```
- [fix: 토큰 사용하지 않는 API에서 응답하지 않는 문제 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/b88e8d27b044b2eb517f792a54651524dd3fb592)