### PR TITLE
API 구현 : 회원 탈퇴

### DIFF
--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -292,6 +292,14 @@ public class UserController {
         return productIds;
     }
 
+    @Operation(summary = "회원 탈퇴")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"회원 탈퇴 완료\"")))
+    @DeleteMapping("/users")
+    public ResponseEntity<?> deleteUser(@AuthenticationPrincipal PrincipalDetails principalDetails) {
+        userService.delete(principalDetails.getUser().getId());
+        return new ResponseEntity<>("회원 탈퇴 완료", HttpStatus.OK);
+    }
+
     @Operation(summary = "유저 즐겨찾기 쇼핑몰 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"즐겨찾기 등록 완료\"")))
     @PostMapping("/favorites/{mallId}")


### PR DESCRIPTION
## API 구현
### 회원 탈퇴
`UserService.delete()`를 활용해 **회원 탈퇴 API**를 구현했습니다.
Fittering 서비스를 이용하는 사용자는 회원 탈퇴 기능을 통해 **원할 때 본인의 회원 정보를 DB에서 삭제할 수 있습니다.**
#6 에서 회원 탈퇴 로직을 구현했었으나 `User` 관련 API를 구현하는 과정에서 누락된 것으로 확인돼 처리했습니다.
- HTTP Method : `DELETE`
- API URI : `/api/v1/users/{userId}`
- [feat: 회원 탈퇴 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/333cbdff27c436c8426ddb9252b73deb24835f06)