### PR TITLE
API 수정 : 쇼핑몰 조회 응답

### DIFF
--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -55,7 +55,7 @@ public class MallController {
     }
 
     @Operation(summary = "쇼핑몰 조회")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallDto.class))))
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMallDto.class)))
     @GetMapping("/malls/{mallId}")
     public ResponseEntity<?> mallRank(@PathVariable("mallId") @NotEmpty Long mallId,
                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
@@ -65,7 +65,7 @@ public class MallController {
     }
 
     @Operation(summary = "쇼핑몰 랭킹 조회")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallDto.class))))
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallWithProductDto.class))))
     @GetMapping("/malls/rank")
     public ResponseEntity<?> mallRank(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ResponseMallWithProductDto> malls = rankService.mallRank(principalDetails.getUser().getId());
@@ -93,7 +93,7 @@ public class MallController {
     }
 
     @Operation(summary = "즐겨찾기 쇼핑몰 상세 조회")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMallDto.class)))
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallWithProductDto.class))))
     @GetMapping("/malls/favorite_malls")
     public ResponseEntity<?> favoriteMall(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ResponseMallWithProductDto> malls = favoriteService.userFavoriteMall(principalDetails.getUser().getId());

--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -2,6 +2,7 @@ package fittering.mall.controller;
 
 import fittering.mall.domain.dto.controller.request.RequestMallDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallPreviewDto;
 import fittering.mall.domain.mapper.MallMapper;
 import io.swagger.v3.oas.annotations.Operation;
@@ -67,7 +68,7 @@ public class MallController {
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallDto.class))))
     @GetMapping("/malls/rank")
     public ResponseEntity<?> mallRank(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        List<ResponseMallDto> malls = rankService.mallRank(principalDetails.getUser().getId());
+        List<ResponseMallWithProductDto> malls = rankService.mallRank(principalDetails.getUser().getId());
         return new ResponseEntity<>(malls, HttpStatus.OK);
     }
 
@@ -95,7 +96,7 @@ public class MallController {
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMallDto.class)))
     @GetMapping("/malls/favorite_malls")
     public ResponseEntity<?> favoriteMall(@AuthenticationPrincipal PrincipalDetails principalDetails) {
-        List<ResponseMallDto> malls = favoriteService.userFavoriteMall(principalDetails.getUser().getId());
+        List<ResponseMallWithProductDto> malls = favoriteService.userFavoriteMall(principalDetails.getUser().getId());
         return new ResponseEntity<>(malls, HttpStatus.OK);
     }
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallDto.java
@@ -5,8 +5,6 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @Builder
 @NoArgsConstructor
@@ -17,6 +15,4 @@ public class ResponseMallDto {
     private String url;
     private String image;
     private String description;
-    private Integer view;
-    private List<ResponseMallRankProductDto> products;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallWithProductDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallWithProductDto.java
@@ -1,0 +1,21 @@
+package fittering.mall.domain.dto.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseMallWithProductDto {
+    private Long id;
+    private String name;
+    private String image;
+    private String description;
+    private Integer view;
+    private List<ResponseMallRankProductDto> products;
+}

--- a/src/main/java/fittering/mall/domain/mapper/MallMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/MallMapper.java
@@ -3,6 +3,7 @@ package fittering.mall.domain.mapper;
 import fittering.mall.domain.dto.controller.request.RequestMallDto;
 import fittering.mall.domain.dto.controller.request.RequestMallRankProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallPreviewDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallRankProductDto;
 import fittering.mall.domain.dto.service.MallPreviewDto;
@@ -25,6 +26,7 @@ public interface MallMapper {
     MallRankProductDto toMallRankProductDto(RequestMallRankProductDto requestMallRankProductDto);
 
     ResponseMallDto toResponseMallDto(Mall mall, Integer view);
+    ResponseMallWithProductDto toResponseMallWithProductDto(Mall mall, Integer view);
     @Mappings({
             @Mapping(source = "product.id", target = "productId"),
             @Mapping(source = "product.image", target = "productImage")

--- a/src/main/java/fittering/mall/service/FavoriteService.java
+++ b/src/main/java/fittering/mall/service/FavoriteService.java
@@ -1,6 +1,6 @@
 package fittering.mall.service;
 
-import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallRankProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
 import fittering.mall.domain.mapper.MallMapper;
@@ -9,7 +9,6 @@ import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.CacheEvict;
 import org.springframework.cache.annotation.Cacheable;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import fittering.mall.domain.RestPage;
@@ -36,10 +35,10 @@ public class FavoriteService {
     private final UserRepository userRepository;
 
     @Cacheable(value = "UserFavoriteMall", key = "#userId")
-    public List<ResponseMallDto> userFavoriteMall(Long userId) {
+    public List<ResponseMallWithProductDto> userFavoriteMall(Long userId) {
 
         List<Favorite> favoriteMalls = favoriteRepository.userFavoriteMall(userId);
-        List<ResponseMallDto> result = new ArrayList<>();
+        List<ResponseMallWithProductDto> result = new ArrayList<>();
 
         favoriteMalls.forEach(favorite -> {
             Mall mall = favorite.getMall();
@@ -58,7 +57,7 @@ public class FavoriteService {
                                                     .build());
             }
 
-            result.add(MallMapper.INSTANCE.toResponseMallDto(mall, 0));
+            result.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, 0));
         });
         return result;
     }

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -1,6 +1,6 @@
 package fittering.mall.service;
 
-import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallPreviewDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallRankProductDto;
 import fittering.mall.domain.mapper.MallMapper;
@@ -51,9 +51,9 @@ public class RankService {
                 .orElseThrow(() -> new NoResultException("rank doesn't exist"));
     }
 
-    public List<ResponseMallDto> mallRank(Long userId) {
+    public List<ResponseMallWithProductDto> mallRank(Long userId) {
         List<Rank> ranks = rankRepository.mallRank(userId);
-        List<ResponseMallDto> result = new ArrayList<>();
+        List<ResponseMallWithProductDto> result = new ArrayList<>();
 
         ranks.forEach(rank -> {
             Mall mall = rank.getMall();
@@ -72,7 +72,7 @@ public class RankService {
                                                     .build());
             }
 
-            result.add(MallMapper.INSTANCE.toResponseMallDto(mall, rank.getView()));
+            result.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, rank.getView()));
         });
         return result;
     }

--- a/src/test/java/fittering/mall/service/FavoriteServiceTest.java
+++ b/src/test/java/fittering/mall/service/FavoriteServiceTest.java
@@ -133,9 +133,9 @@ class FavoriteServiceTest {
 
         RestPage<ResponseProductPreviewDto> products = favoriteService.userFavoriteProduct(user.getId(), PageRequest.of(0, 10));
         assertThat(products.getTotalElements()).isEqualTo(3);
-        compareProduct(product, products.getContent().get(0));
+        compareProduct(product, products.getContent().get(2));
         compareProduct(product2, products.getContent().get(1));
-        compareProduct(product3, products.getContent().get(2));
+        compareProduct(product3, products.getContent().get(0));
 
         favoriteService.deleteFavoriteProduct(user.getId(), product.getId());
         favoriteService.deleteFavoriteProduct(user.getId(), product2.getId());

--- a/src/test/java/fittering/mall/service/FavoriteServiceTest.java
+++ b/src/test/java/fittering/mall/service/FavoriteServiceTest.java
@@ -1,6 +1,6 @@
 package fittering.mall.service;
 
-import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
 import fittering.mall.domain.dto.service.SignUpDto;
 import jakarta.transaction.Transactional;
@@ -59,10 +59,10 @@ class FavoriteServiceTest {
         savedFavorite.add(createMallDto(savedFavorite2));
         savedFavorite.add(createMallDto(savedFavorite3));
 
-        List<ResponseMallDto> findFavorites = favoriteService.userFavoriteMall(user.getId());
+        List<ResponseMallWithProductDto> findFavorites = favoriteService.userFavoriteMall(user.getId());
         for (int i=0; i<findFavorites.size(); i++) {
             MallDto savedMallDto = savedFavorite.get(i);
-            ResponseMallDto findMallDto = findFavorites.get(i);
+            ResponseMallWithProductDto findMallDto = findFavorites.get(i);
             checkMallDto(savedMallDto, findMallDto);
         }
 
@@ -70,7 +70,7 @@ class FavoriteServiceTest {
         favoriteService.deleteFavoriteMall(user.getId(), mall2.getId());
         favoriteService.deleteFavoriteMall(user.getId(), mall3.getId());
 
-        List<ResponseMallDto> deletedUserList = favoriteService.userFavoriteMall(user.getId());
+        List<ResponseMallWithProductDto> deletedUserList = favoriteService.userFavoriteMall(user.getId());
         assertThat(deletedUserList.size()).isEqualTo(0);
     }
 
@@ -145,7 +145,7 @@ class FavoriteServiceTest {
         assertThat(deletedProducts.getTotalElements()).isEqualTo(0);
     }
 
-    private static void checkMallDto(MallDto savedMallDto, ResponseMallDto findMallDto) {
+    private static void checkMallDto(MallDto savedMallDto, ResponseMallWithProductDto findMallDto) {
         assertThat(savedMallDto.getId()).isEqualTo(findMallDto.getId());
         assertThat(savedMallDto.getName()).isEqualTo(findMallDto.getName());
         assertThat(savedMallDto.getImage()).isEqualTo(findMallDto.getImage());

--- a/src/test/java/fittering/mall/service/ProductServiceTest.java
+++ b/src/test/java/fittering/mall/service/ProductServiceTest.java
@@ -151,22 +151,22 @@ class ProductServiceTest {
     void productWithCategory() {
         Page<ResponseProductPreviewDto> findProductByCategory =
                 productService.productWithCategory(topCategory.getId(), "M", 0L, PageRequest.of(0, 10));
-        compareProduct(product, findProductByCategory.getContent().get(0));
-        compareProduct(product2, findProductByCategory.getContent().get(1));
+        compareProduct(product, findProductByCategory.getContent().get(4));
+        compareProduct(product2, findProductByCategory.getContent().get(3));
         compareProduct(product3, findProductByCategory.getContent().get(2));
-        compareProduct(product4, findProductByCategory.getContent().get(3));
-        compareProduct(product5, findProductByCategory.getContent().get(4));
+        compareProduct(product4, findProductByCategory.getContent().get(1));
+        compareProduct(product5, findProductByCategory.getContent().get(0));
     }
 
     @Test
     void productWithCategoryOfMall() {
         Page<ResponseProductPreviewDto> findProductByCategoryOfMall =
                 productService.productWithCategoryOfMall(mall.getId(), topCategory.getId(), "M", 0L, PageRequest.of(0, 10));
-        compareProduct(product, findProductByCategoryOfMall.getContent().get(0));
-        compareProduct(product2, findProductByCategoryOfMall.getContent().get(1));
+        compareProduct(product, findProductByCategoryOfMall.getContent().get(4));
+        compareProduct(product2, findProductByCategoryOfMall.getContent().get(3));
         compareProduct(product3, findProductByCategoryOfMall.getContent().get(2));
-        compareProduct(product4, findProductByCategoryOfMall.getContent().get(3));
-        compareProduct(product5, findProductByCategoryOfMall.getContent().get(4));
+        compareProduct(product4, findProductByCategoryOfMall.getContent().get(1));
+        compareProduct(product5, findProductByCategoryOfMall.getContent().get(0));
     }
 
     @Test
@@ -439,7 +439,9 @@ class ProductServiceTest {
     void updateView() {
         productService.updateView(product.getId());
         Product findProduct = productService.findById(product.getId());
-        assertThat(findProduct.getView()).isEqualTo(1);
+//        assertThat(findProduct.getView()).isEqualTo(1);
+        int view = Integer.parseInt(redisTemplate.opsForValue().get("Batch:Product_view_" + findProduct.getId()).toString());
+        assertThat(view).isEqualTo(1);
     }
 
     @Test

--- a/src/test/java/fittering/mall/service/RankServiceTest.java
+++ b/src/test/java/fittering/mall/service/RankServiceTest.java
@@ -1,6 +1,6 @@
 package fittering.mall.service;
 
-import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallRankProductDto;
 import fittering.mall.domain.dto.service.MallDto;
 import fittering.mall.domain.dto.service.SignUpDto;
@@ -131,7 +131,7 @@ class RankServiceTest {
         Rank rank1 = rankService.save(user.getId(), mall.getId());
         Rank rank2 = rankService.save(user.getId(), mall2.getId());
 
-        List<ResponseMallDto> mallDtos = rankService.mallRank(user.getId());
+        List<ResponseMallWithProductDto> mallDtos = rankService.mallRank(user.getId());
 
         assertThat(mallDtos.get(0).getId()).isEqualTo(rank1.getMall().getId());
         assertThat(mallDtos.get(0).getName()).isEqualTo(rank1.getMall().getName());

--- a/src/test/java/fittering/mall/service/RankServiceTest.java
+++ b/src/test/java/fittering/mall/service/RankServiceTest.java
@@ -160,7 +160,9 @@ class RankServiceTest {
 
         rank1 = rankService.findById(rank1.getId());
         rank2 = rankService.findById(rank2.getId());
-        assertThat(rank1.getView()).isEqualTo(1L);
-        assertThat(rank2.getView()).isEqualTo(1L);
+        int firstView = Integer.parseInt(redisTemplate.opsForValue().get("Batch:Rank_view_" + rank1.getId()).toString());
+        int secondView = Integer.parseInt(redisTemplate.opsForValue().get("Batch:Rank_view_" + rank2.getId()).toString());
+        assertThat(firstView).isEqualTo(1L);
+        assertThat(secondView).isEqualTo(1L);
     }
 }

--- a/src/test/java/fittering/mall/service/SearchServiceTest.java
+++ b/src/test/java/fittering/mall/service/SearchServiceTest.java
@@ -128,9 +128,9 @@ class SearchServiceTest {
     void products() {
         RestPage<ResponseProductPreviewDto> shirtProducts = searchService.products("셔츠", "M", 0L, PageRequest.of(0, 10));
         List<Product> products = List.of(product, product2, product3);
-        for (int i=0; i<products.size(); i++) {
+        for (int i=0, j=products.size()-1; i<products.size() && j>=0; i++, j--) {
             Product product = products.get(i);
-            ResponseProductPreviewDto shirtProduct = shirtProducts.getContent().get(i);
+            ResponseProductPreviewDto shirtProduct = shirtProducts.getContent().get(j);
             compareProduct(product, shirtProduct);
         }
     }

--- a/src/test/java/fittering/mall/service/UserServiceTest.java
+++ b/src/test/java/fittering/mall/service/UserServiceTest.java
@@ -68,7 +68,7 @@ class UserServiceTest {
 
     @BeforeEach
     void setUp() {
-        user = userService.save(new SignUpDto("test", "password", "test@test.com", "M", 1, 2, 3));
+        user = userService.save(new SignUpDto("testuser", "password", "t@test.com", "M", 1, 2, 3));
         category = categoryService.save("top");
         subCategory = categoryService.saveSubCategory("top", "shirt");
         mall = mallService.save(new MallDto(1L, "testMall1", "test.com", "image.jpg", "desc", 0, new ArrayList<>()));
@@ -119,7 +119,7 @@ class UserServiceTest {
 
     @Test
     void infoUpdate() {
-        RequestUserDto userDto = new RequestUserDto("test@test.com", "testUser", "M", 1996, 12, 25);
+        RequestUserDto userDto = new RequestUserDto("t@test.com", "testUser", "M", 1996, 12, 25);
         userService.infoUpdate(userDto, user.getId());
 
         assertThat(user.getEmail()).isEqualTo(userDto.getEmail());
@@ -187,14 +187,14 @@ class UserServiceTest {
 
     @Test
     void usernameExist() {
-        assertThat(userService.usernameExist("test")).isTrue();
-        assertThat(userService.usernameExist("tes")).isFalse();
+        assertThat(userService.usernameExist("testuser")).isTrue();
+        assertThat(userService.usernameExist("testuse")).isFalse();
     }
 
     @Test
     void emailExist() {
-        assertThat(userService.emailExist("test@test.com")).isTrue();
-        assertThat(userService.emailExist("tes@tes.com")).isFalse();
+        assertThat(userService.emailExist("t@test.com")).isTrue();
+        assertThat(userService.emailExist("t@tes.com")).isFalse();
     }
 
     @Test


### PR DESCRIPTION
## API 수정
### 쇼핑몰 조회 응답
쇼핑몰 조회 시 사용하는 API에서 상품 정보 `products`를 응답에 포함하고 있었으나 다른 API에서 가져올 수 있어 사용하지 않고 있었습니다.
**사용하지 않을 정보를 포함할 필요가 없으므로** 팀 내 회의를 통해 응답 DTO `ResponseMallDto`에서 `products`를 제거했습니다.
또한 Swagger 문서에서 응답 형태가 **`ResponseMallDto` 1개**이므로 `List<ResponseMallDto>`로 표시되지 않도록 수정했습니다.
- [fix: 쇼핑몰 조회 시 사용하지 않는 필드 제거](https://github.com/YeolJyeongKong/fittering-BE/commit/1bc9b853912f715f267792208948e57d34e3581e)

### 즐겨찾기 쇼핑몰 상세 조회
즐겨찾기 쇼핑몰 상세 조회 API에서 **`url` 필드를 사용하지 않아 `ResponseMallWithProductDto`에서 제거했습니다.**
기존 응답 타입은 `ResponseMallDto`였으나, 위에서 사용하는 타입과 구분하기 위해 `ResponseMallWithProductDto`로 재정의 했습니다.
또한 Swagger 문서에서 응답 형태를 `List<ResponseMallWithProductDto>`로 수정했습니다.
```java
public class ResponseMallWithProductDto {
    private Long id;
    private String name;
    private String image;
    private String description;
    private Integer view;
    private List<ResponseMallRankProductDto> products;
}
```
- [feat: 쇼핑몰과 상품을 같이 조회하는 DTO 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/a8dad516408dece9571313fdd0cd863afd645031)
- [refactor: 쇼핑몰 조회 API에 적절한 DTO로 응답하도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/bdd399ef67929a721307ba9de1b3cbe7c2f93cd7)
- [refactor: Swagger 문서에서 쇼핑몰 조회 API 응답 type 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/beef4cc14b10a0acb0ee31c1a76fc631c1118f96)
