### PR TITLE
ELK 설정 : 로그 분석 및 시각화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,8 @@ dependencies {
 	implementation "org.springframework.boot:spring-boot-starter-oauth2-client"
 	implementation 'org.springframework.boot:spring-boot-starter-mail'
 
+	implementation 'net.logstash.logback:logstash-logback-encoder:4.11'
+
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,9 @@
+<configuration scan="true" scanPeriod="30 seconds">
+    <appender name="LOGSTASH" class="net.logstash.logback.appender.LogstashTcpSocketAppender">
+        <destination>127.0.0.1:4560</destination>
+        <encoder class="net.logstash.logback.encoder.LogstashEncoder"></encoder>
+    </appender>
+    <root level="INFO">
+        <appender-ref ref="LOGSTASH"/>
+    </root>
+</configuration>


### PR DESCRIPTION
# ELK 설정
<img width="1190" alt="image" src="https://github.com/YeolJyeongKong/fittering-BE/assets/61930524/0c44d97a-444f-4526-8208-2979b52ccdbe">

**Logstash**로 로그 수집 및 전처리를, **Elasticsearch**로 로그 관리를, **Kibana**로 저장된 로그 정보를 시각화해 모니터링할 수 있게 합니다.
Logstash + Elasticsearch + Kibana(이하 ELK) 모두 Docker 컨테이너 환경에서 운영되며,
`Logstash`는 스프링 프로젝트 [Fittering-BE](https://github.com/YeolJyeongKong/fittering-BE)에서 생성하는 로그를 수집해 `Elasticsearch`로 전달합니다.
- 📄 : [[Spring] 스프링 부트에 ELK 적용하기](https://yooniversal.github.io/project/post257/)

## Logstash
### logback 설정
프로젝트에서 생성되는 로그를 수집하기 위해 logback 의존성을 추가하고 설정 파일(XML)을 등록했습니다.
수집한 로그를 localhost에서 **4560** 포트로 전송합니다.

기존에는 배포 시 실행되는 shell 파일에 의해 로그를 `application.log`에 저장하도록 설정했으나,
`logback` 설정을 하면서 더 이상 `application.log`에 로그가 남지 않고 그대로 `Logstash`로 전송합니다.
- [feat: logback 의존성 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/6edb4c7e236fd71d5873476e3bab2f1f71842ed7)
- [feat: logback XML 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/af2fdca6664c248b7c9d3455ad517763b5e6f266)

### Logstash 설정
`Logstash`는 Docker 컨테이너 환경에서 운영되며, 다음 설정 파일 `logstash.conf`를 사용합니다.
로그를 `4560` 포트에서 json 형태로 받은 뒤 전처리를 거쳐 `Elasticsearch`로 전송합니다.
인덱스 명은 `logstash-{날짜}`로 설정했습니다.
```s
input {
    tcp {
        port => 4560
        codec => json_lines
    }
}

output {
    elasticsearch {
        hosts => ["elasticsearch:9200"]
        index => "logstash-%{+YYYY.MM.dd}"
    }
}
```

### Elasticsearch, Kibana
`Elasticsearch`는 **9200** 포트를, `Kibana`는 **5601** 포트를 사용합니다.

다음은 `Kibana`에서 로그를 시각화한 결과입니다.
<img width="1135" alt="image" src="https://github.com/YeolJyeongKong/fittering-BE/assets/61930524/7b268830-b247-4aff-bb39-094627e47341">

### Version
ELK 모두 `7.6.2` 버전을 사용했습니다.