### PR TITLE
Kafka 적용 : DB 간 데이터 동기화

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -58,6 +58,9 @@ dependencies {
 
 	implementation 'net.logstash.logback:logstash-logback-encoder:4.11'
 
+	implementation 'org.springframework.kafka:spring-kafka'
+	implementation 'org.json:json:20230227'
+
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'
 

--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,7 @@ dependencies {
 
 	implementation 'org.springframework.kafka:spring-kafka'
 	implementation 'org.json:json:20230227'
+	implementation 'org.springframework.cloud:spring-cloud-starter-aws:2.2.6.RELEASE'
 
 	implementation 'org.mapstruct:mapstruct:1.5.3.Final'
 	annotationProcessor 'org.mapstruct:mapstruct-processor:1.5.3.Final'

--- a/src/main/java/fittering/mall/MallApplication.java
+++ b/src/main/java/fittering/mall/MallApplication.java
@@ -5,8 +5,10 @@ import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.Bean;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableJpaAuditing
 @EnableScheduling
 @SpringBootApplication
 public class MallApplication {

--- a/src/main/java/fittering/mall/config/RestTemplateConfig.java
+++ b/src/main/java/fittering/mall/config/RestTemplateConfig.java
@@ -2,13 +2,18 @@ package fittering.mall.config;
 
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.converter.StringHttpMessageConverter;
 import org.springframework.web.client.RestTemplate;
+
+import java.nio.charset.StandardCharsets;
 
 @Configuration
 public class RestTemplateConfig {
 
     @Bean
     public RestTemplate restTemplate() {
-        return new RestTemplate();
+        RestTemplate restTemplate = new RestTemplate();
+        restTemplate.getMessageConverters().add(0, new StringHttpMessageConverter(StandardCharsets.UTF_8));
+        return restTemplate;
     }
 }

--- a/src/main/java/fittering/mall/config/S3Config.java
+++ b/src/main/java/fittering/mall/config/S3Config.java
@@ -1,0 +1,34 @@
+package fittering.mall.config;
+
+import com.amazonaws.auth.AWSStaticCredentialsProvider;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3ClientBuilder;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class S3Config {
+    @Value("${cloud.aws.credentials.access-key}")
+    private String accessKey;
+    @Value("${cloud.aws.credentials.secret-key}")
+    private String secretKey;
+    @Value("${cloud.aws.region.static}")
+    private String region;
+
+    @Bean
+    @Primary
+    public BasicAWSCredentials awsCredentialsProvider(){
+        return new BasicAWSCredentials(accessKey, secretKey);
+    }
+
+    @Bean
+    public AmazonS3 amazonS3() {
+        return AmazonS3ClientBuilder.standard()
+                .withRegion(region)
+                .withCredentials(new AWSStaticCredentialsProvider(awsCredentialsProvider()))
+                .build();
+    }
+}

--- a/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
@@ -1,0 +1,166 @@
+package fittering.mall.config.kafka;
+
+import fittering.mall.config.kafka.domain.KafkaProductResponse;
+import fittering.mall.config.kafka.domain.dto.CrawledMallDto;
+import fittering.mall.config.kafka.domain.dto.CrawledProductDto;
+import fittering.mall.config.kafka.domain.dto.CrawledSizeDto;
+import fittering.mall.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class KafkaConsumer {
+
+    private final ProductService productService;
+
+    @KafkaListener(topics = "crawling-topic-0", groupId = "crawl-group-id")
+    public void consumeCrawledProductsV0(String productJson) {
+        updateCrawledProductsProduct(productJson);
+    }
+
+    @KafkaListener(topics = "crawling-topic-1", groupId = "crawl-group-id")
+    public void consumeCrawledProductsV1(String productJson) {
+        updateCrawledProductsProduct(productJson);
+    }
+
+    @KafkaListener(topics = "crawling-topic-2", groupId = "crawl-group-id")
+    public void consumeCrawledProductsV2(String productJson) {
+        updateCrawledProductsProduct(productJson);
+    }
+
+    @KafkaListener(topics = "crawling-topic-3", groupId = "crawl-group-id")
+    public void consumeCrawledProductsV3(String productJson) {
+        updateCrawledProductsProduct(productJson);
+    }
+
+    @KafkaListener(topics = "crawling-topic-4", groupId = "crawl-group-id")
+    public void consumeCrawledProductsV4(String productJson) {
+        updateCrawledProductsProduct(productJson);
+    }
+
+    private void updateCrawledProductsProduct(String productJson) {
+        KafkaProductResponse productResponse = getProductFromJson(productJson);
+        CrawledProductDto product = productResponse.getProduct();
+        CrawledMallDto mall = productResponse.getMall();
+        List<CrawledSizeDto> sizes = productResponse.getSize();
+        List<String> imagePaths = productResponse.getImagepath();
+        productService.updateCrawledProducts(product, mall, sizes, imagePaths);
+    }
+
+    private KafkaProductResponse getProductFromJson(String productJson) {
+        JSONObject jsonObject = new JSONObject(productJson);
+        CrawledProductDto productDto = createProductDto(jsonObject);
+        CrawledMallDto mallDto = createMallDto(jsonObject);
+        List<CrawledSizeDto> sizeDtos = createSizeDtos(jsonObject);
+        List<String> imagePaths = createImagePaths(jsonObject);
+        return KafkaProductResponse.builder()
+                .product(productDto)
+                .mall(mallDto)
+                .size(sizeDtos)
+                .imagepath(imagePaths)
+                .build();
+    }
+
+    private CrawledProductDto createProductDto(JSONObject element) {
+        JSONObject product = element.getJSONObject("product");
+        long product_id = product.getInt("product_id");
+        int price = product.getInt("price");
+        String name = product.getString("name");
+        String gender = product.getString("gender");
+        long category_id = product.getInt("category_id");
+        long sub_category_id = product.getInt("sub_category_id");
+        int type = (int) (category_id - 1);
+        String url = product.getString("url");
+        long mall_id = product.getInt("mall_id");
+        String description_path = product.getString("description_path");
+        String updated_at = product.getString("updated_at");
+        int disabled = product.getInt("disabled");
+        return CrawledProductDto.builder()
+                .product_id(product_id)
+                .price(price)
+                .type(type)
+                .name(name)
+                .gender(gender)
+                .category_id(category_id)
+                .sub_category_id(sub_category_id)
+                .url(url)
+                .mall_id(mall_id)
+                .description_path(description_path)
+                .updated_at(updated_at)
+                .disabled(disabled)
+                .build();
+    }
+
+    private CrawledMallDto createMallDto(JSONObject element) {
+        JSONObject mall = element.getJSONObject("mall");
+        long mall_id = mall.getInt("mall_id");
+        String name = mall.getString("name");
+        String url = mall.getString("url");
+        String description = mall.getString("description");
+        String image = mall.getString("image");
+        return CrawledMallDto.builder()
+                .mall_id(mall_id)
+                .name(name)
+                .url(url)
+                .description(description)
+                .image(image)
+                .build();
+    }
+
+    private List<CrawledSizeDto> createSizeDtos(JSONObject element) {
+        List<CrawledSizeDto> sizeDtos = new ArrayList<>();
+        JSONArray sizes = element.getJSONArray("size");
+        for (int i=0; i<sizes.length(); ++i) {
+            JSONObject size = sizes.getJSONObject(i);
+            double full = size.getDouble("full");
+            double shoulder = size.getDouble("shoulder");
+            double chest = size.getDouble("chest");
+            double sleeve = size.getDouble("sleeve");
+            double waist = size.getDouble("waist");
+            double thigh = size.getDouble("thigh");
+            double rise = size.getDouble("rise");
+            double bottomWidth = size.getDouble("bottom_width");
+            double hipWidth = size.getDouble("hip_width");
+            double armHall = size.getDouble("arm_hall");
+            double hip = size.getDouble("hip");
+            double sleeveWidth = size.getDouble("sleeve_width");
+
+            String name = size.getString("name");
+            sizeDtos.add(CrawledSizeDto.builder()
+                    .full(full == 0.0 ? null : full)
+                    .shoulder(shoulder == 0.0 ? null : shoulder)
+                    .chest(chest == 0.0 ? null : chest)
+                    .sleeve(sleeve == 0.0 ? null : sleeve)
+                    .waist(waist == 0.0 ? null : waist)
+                    .thigh(thigh == 0.0 ? null : thigh)
+                    .rise(rise == 0.0 ? null : rise)
+                    .bottom_width(bottomWidth == 0.0 ? null : bottomWidth)
+                    .hip_width(hipWidth == 0.0 ? null : hipWidth)
+                    .arm_hall(armHall == 0.0 ? null : armHall)
+                    .hip(hip == 0.0 ? null : hip)
+                    .sleeve_width(sleeveWidth == 0.0 ? null : sleeveWidth)
+                    .name(name)
+                    .build());
+        }
+        return sizeDtos;
+    }
+
+    private List<String> createImagePaths(JSONObject element) {
+        List<String> imagePaths = new ArrayList<>();
+        JSONArray imagepaths = element.getJSONArray("imagepath");
+        for (int i=0; i<imagepaths.length(); ++i) {
+            String path = imagepaths.getString(i);
+            imagePaths.add(path);
+        }
+        return imagePaths;
+    }
+}

--- a/src/main/java/fittering/mall/config/kafka/KafkaProducer.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaProducer.java
@@ -1,0 +1,108 @@
+package fittering.mall.config.kafka;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import fittering.mall.config.kafka.domain.KafkaProductRequest;
+import fittering.mall.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class KafkaProducer {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ProductService productService;
+    private final RestTemplate restTemplate;
+
+    private static final String CRAWLED_PRODUCT_TOPIC = "crawling-topic-";
+    private static final int TOPIC_NUMBER = 5;
+
+    @Value("${ML.API.PRODUCT.COUNT}")
+    private String CRAWLED_PRODUCT_COUNT_API;
+    @Value("${ML.API.PRODUCT.INFO}")
+    private String CRAWLED_PRODUCT_INFO_API;
+
+    public void callCrawledProductCountAPI() throws JsonProcessingException {
+        URI uri = UriComponentsBuilder.fromUriString(CRAWLED_PRODUCT_COUNT_API)
+                .build()
+                .toUri();
+        String responseBody = restTemplate.getForObject(uri, String.class);
+        int productsCount = getProductsCountFromBody(responseBody);
+        LocalDateTime timeCriteria = productService.productsOfMaxUpdatedAt();
+        produceCrawledProducts(productsCount, timeCriteria);
+    }
+
+    public void produceCrawledProducts(int productsCount, LocalDateTime timeCriteria) throws JsonProcessingException {
+        int batchSize = productsCount % 100 == 0 ? productsCount / 100 : productsCount / 100 + 1;
+        for (int i=0; i<batchSize; ++i) {
+            URI uri = UriComponentsBuilder.fromUriString(CRAWLED_PRODUCT_INFO_API)
+                    .build()
+                    .toUri();
+
+            int startId = i*100 + 1;
+            int endId = i != batchSize-1 ? (i+1) * 100 : productsCount;
+            KafkaProductRequest request = KafkaProductRequest.builder()
+                    .range(List.of(startId, endId))
+                    .updated_at(timeCriteriaToString(timeCriteria))
+                    .build();
+
+            HttpHeaders headers = new HttpHeaders();
+            headers.setContentType(MediaType.APPLICATION_JSON);
+            String jsonRequest = convertProductRequestToJson(request);
+            HttpEntity<String> httpEntity = new HttpEntity<>(jsonRequest, headers);
+            String responseBody = restTemplate.postForObject(uri, httpEntity, String.class);
+
+            int sendCount = 0;
+            for (String productJson : getProductsJsonFromBody(responseBody)) {
+                sendCount = (sendCount + 1) % TOPIC_NUMBER;
+                String topic = CRAWLED_PRODUCT_TOPIC + sendCount;
+                kafkaTemplate.send(topic, productJson);
+            }
+        }
+    }
+
+    private static String timeCriteriaToString(LocalDateTime timeCriteria) {
+        DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss");
+        return timeCriteria.format(formatter);
+    }
+
+    private static int getProductsCountFromBody(String responseBody) {
+        JSONObject jObject = new JSONObject(responseBody);
+        return jObject.getInt("body");
+    }
+
+    private static List<String> getProductsJsonFromBody(String responseBody) {
+        List<String> productsJson = new ArrayList<>();
+        JSONObject jObject = new JSONObject(responseBody);
+        JSONArray jArray = jObject.getJSONArray("body");
+
+        for (int i=0; i<jArray.length(); ++i) {
+            productsJson.add(jArray.getJSONObject(i).toString());
+        }
+
+        return productsJson;
+    }
+
+    private static String convertProductRequestToJson(KafkaProductRequest request) throws JsonProcessingException {
+        ObjectMapper mapper = new ObjectMapper();
+        return mapper.writeValueAsString(request);
+    }
+}

--- a/src/main/java/fittering/mall/config/kafka/domain/KafkaProductRequest.java
+++ b/src/main/java/fittering/mall/config/kafka/domain/KafkaProductRequest.java
@@ -1,0 +1,13 @@
+package fittering.mall.config.kafka.domain;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+@Getter
+@Builder
+public class KafkaProductRequest {
+    public List<Integer> range;
+    public String updated_at;
+}

--- a/src/main/java/fittering/mall/config/kafka/domain/KafkaProductResponse.java
+++ b/src/main/java/fittering/mall/config/kafka/domain/KafkaProductResponse.java
@@ -1,0 +1,19 @@
+package fittering.mall.config.kafka.domain;
+
+import fittering.mall.config.kafka.domain.dto.CrawledMallDto;
+import fittering.mall.config.kafka.domain.dto.CrawledProductDto;
+import fittering.mall.config.kafka.domain.dto.CrawledSizeDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter @Setter
+@Builder
+public class KafkaProductResponse {
+    private CrawledProductDto product;
+    private CrawledMallDto mall;
+    private List<CrawledSizeDto> size;
+    private List<String> imagepath;
+}

--- a/src/main/java/fittering/mall/config/kafka/domain/dto/CrawledMallDto.java
+++ b/src/main/java/fittering/mall/config/kafka/domain/dto/CrawledMallDto.java
@@ -1,0 +1,15 @@
+package fittering.mall.config.kafka.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@Builder
+public class CrawledMallDto {
+    private Long mall_id;
+    private String name;
+    private String url;
+    private String description;
+    private String image;
+}

--- a/src/main/java/fittering/mall/config/kafka/domain/dto/CrawledProductDto.java
+++ b/src/main/java/fittering/mall/config/kafka/domain/dto/CrawledProductDto.java
@@ -1,0 +1,22 @@
+package fittering.mall.config.kafka.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@Builder
+public class CrawledProductDto {
+    private Long product_id;
+    private Integer price;
+    private Integer type;
+    private String name;
+    private String gender;
+    private Long category_id;
+    private Long sub_category_id;
+    private String url;
+    private Long mall_id;
+    private String description_path;
+    private String updated_at;
+    private Integer disabled;
+}

--- a/src/main/java/fittering/mall/config/kafka/domain/dto/CrawledSizeDto.java
+++ b/src/main/java/fittering/mall/config/kafka/domain/dto/CrawledSizeDto.java
@@ -1,0 +1,23 @@
+package fittering.mall.config.kafka.domain.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter @Setter
+@Builder
+public class CrawledSizeDto {
+    private Double full;
+    private Double shoulder;
+    private Double chest;
+    private Double sleeve;
+    private Double waist;
+    private Double thigh;
+    private Double rise;
+    private Double bottom_width;
+    private Double hip_width;
+    private Double arm_hall;
+    private Double hip;
+    private Double sleeve_width;
+    private String name;
+}

--- a/src/main/java/fittering/mall/domain/BaseEntity.java
+++ b/src/main/java/fittering/mall/domain/BaseEntity.java
@@ -1,0 +1,33 @@
+package fittering.mall.domain;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.domain.AuditorAware;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+@MappedSuperclass
+@EntityListeners({AuditingEntityListener.class})
+@Getter
+public class BaseEntity {
+
+    @CreatedDate
+    @Column(updatable = false, name = "created_at")
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Bean
+    public AuditorAware<String> auditorProvider() {
+        return () -> Optional.of("BaseEntity Auditor is working");
+    }
+}

--- a/src/main/java/fittering/mall/domain/BaseEntity.java
+++ b/src/main/java/fittering/mall/domain/BaseEntity.java
@@ -30,4 +30,8 @@ public class BaseEntity {
     public AuditorAware<String> auditorProvider() {
         return () -> Optional.of("BaseEntity Auditor is working");
     }
+
+    public void updateTime(LocalDateTime updatedAt) {
+        this.updatedAt = updatedAt;
+    }
 }

--- a/src/main/java/fittering/mall/domain/BaseEntity.java
+++ b/src/main/java/fittering/mall/domain/BaseEntity.java
@@ -25,7 +25,7 @@ public class BaseEntity {
     @JsonSerialize(using = LocalDateTimeSerializer.class)
     @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @CreatedDate
-    @Column(updatable = false, name = "created_at")
+    @Column(name = "created_at")
     private LocalDateTime createdAt;
 
     @JsonSerialize(using = LocalDateTimeSerializer.class)

--- a/src/main/java/fittering/mall/domain/BaseEntity.java
+++ b/src/main/java/fittering/mall/domain/BaseEntity.java
@@ -1,5 +1,9 @@
 package fittering.mall.domain;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
+import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
 import jakarta.persistence.MappedSuperclass;
@@ -18,10 +22,14 @@ import java.util.Optional;
 @Getter
 public class BaseEntity {
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @CreatedDate
     @Column(updatable = false, name = "created_at")
     private LocalDateTime createdAt;
 
+    @JsonSerialize(using = LocalDateTimeSerializer.class)
+    @JsonDeserialize(using = LocalDateTimeDeserializer.class)
     @LastModifiedDate
     @Column(name = "updated_at")
     private LocalDateTime updatedAt;

--- a/src/main/java/fittering/mall/domain/entity/Bottom.java
+++ b/src/main/java/fittering/mall/domain/entity/Bottom.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Bottom {
+public class Bottom extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "bottom_id")

--- a/src/main/java/fittering/mall/domain/entity/Category.java
+++ b/src/main/java/fittering/mall/domain/entity/Category.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Category {
+public class Category extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "category_id")

--- a/src/main/java/fittering/mall/domain/entity/Dress.java
+++ b/src/main/java/fittering/mall/domain/entity/Dress.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -12,7 +13,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Dress {
+public class Dress extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "dress_id")

--- a/src/main/java/fittering/mall/domain/entity/Favorite.java
+++ b/src/main/java/fittering/mall/domain/entity/Favorite.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Builder
 @Table(name = "favorite")
 @AllArgsConstructor
-public class Favorite {
+public class Favorite extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "favorite_id")

--- a/src/main/java/fittering/mall/domain/entity/Mall.java
+++ b/src/main/java/fittering/mall/domain/entity/Mall.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -15,7 +16,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Mall {
+public class Mall extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "mall_id")

--- a/src/main/java/fittering/mall/domain/entity/Measurement.java
+++ b/src/main/java/fittering/mall/domain/entity/Measurement.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -13,7 +14,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Getter
 @Builder
 @AllArgsConstructor
-public class Measurement {
+public class Measurement extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "measurement_id")

--- a/src/main/java/fittering/mall/domain/entity/Outer.java
+++ b/src/main/java/fittering/mall/domain/entity/Outer.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -10,7 +11,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Table(name = "`outer`")
 @NoArgsConstructor(access = PROTECTED)
-public class Outer {
+public class Outer extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "outer_id")

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -44,7 +44,6 @@ public class Product extends BaseEntity {
     @Transient public static final int TOP = 1;
     @Transient public static final int DRESS = 2;
     @Transient public static final int BOTTOM = 3;
-    @Transient private static final int TRUE = 1;
 
     @NonNull
     private String image;
@@ -59,7 +58,7 @@ public class Product extends BaseEntity {
     private Integer timeView;
 
     @NonNull
-    private Boolean disabled;
+    private Integer disabled;
 
     @JsonIgnore
     @ManyToOne(fetch = LAZY)
@@ -125,7 +124,7 @@ public class Product extends BaseEntity {
 
     public void updateInfo(Integer price, Integer disabled, LocalDateTime updated_at) {
         this.price = price;
-        this.disabled = disabled == TRUE;
+        this.disabled = disabled;
         super.updateTime(updated_at);
     }
 }

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
@@ -14,7 +15,7 @@ import static jakarta.persistence.FetchType.LAZY;
 @Getter
 @Builder
 @AllArgsConstructor
-public class Product {
+public class Product extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "product_id")

--- a/src/main/java/fittering/mall/domain/entity/Product.java
+++ b/src/main/java/fittering/mall/domain/entity/Product.java
@@ -6,6 +6,7 @@ import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +44,7 @@ public class Product extends BaseEntity {
     @Transient public static final int TOP = 1;
     @Transient public static final int DRESS = 2;
     @Transient public static final int BOTTOM = 3;
+    @Transient private static final int TRUE = 1;
 
     @NonNull
     private String image;
@@ -55,6 +57,9 @@ public class Product extends BaseEntity {
 
     @NonNull
     private Integer timeView;
+
+    @NonNull
+    private Boolean disabled;
 
     @JsonIgnore
     @ManyToOne(fetch = LAZY)
@@ -116,5 +121,11 @@ public class Product extends BaseEntity {
 
     public void initializeTimeView() {
         timeView = 0;
+    }
+
+    public void updateInfo(Integer price, Integer disabled, LocalDateTime updated_at) {
+        this.price = price;
+        this.disabled = disabled == TRUE;
+        super.updateTime(updated_at);
     }
 }

--- a/src/main/java/fittering/mall/domain/entity/ProductDescription.java
+++ b/src/main/java/fittering/mall/domain/entity/ProductDescription.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -13,7 +14,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class ProductDescription {
+public class ProductDescription extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "description_images_id")

--- a/src/main/java/fittering/mall/domain/entity/Rank.java
+++ b/src/main/java/fittering/mall/domain/entity/Rank.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Getter
 @Table(name = "`rank`")
 @NoArgsConstructor(access = PROTECTED)
-public class Rank {
+public class Rank extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "rank_id")

--- a/src/main/java/fittering/mall/domain/entity/Recent.java
+++ b/src/main/java/fittering/mall/domain/entity/Recent.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.datatype.jsr310.deser.LocalDateTimeDeserializer;
 import com.fasterxml.jackson.datatype.jsr310.ser.LocalDateTimeSerializer;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,7 +20,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Recent {
+public class Recent extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "recent_id")

--- a/src/main/java/fittering/mall/domain/entity/RecentRecommendation.java
+++ b/src/main/java/fittering/mall/domain/entity/RecentRecommendation.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -14,7 +15,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class RecentRecommendation {
+public class RecentRecommendation extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "recent_recommendation_id")
@@ -36,6 +37,5 @@ public class RecentRecommendation {
     public RecentRecommendation(User user, Product product) {
         this.user = user;
         this.product = product;
-        updatedAt = LocalDateTime.now();
     }
 }

--- a/src/main/java/fittering/mall/domain/entity/Size.java
+++ b/src/main/java/fittering/mall/domain/entity/Size.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.validator.constraints.Length;
@@ -11,7 +12,7 @@ import static jakarta.persistence.FetchType.*;
 @Getter
 @Builder
 @AllArgsConstructor
-public class Size {
+public class Size extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "size_id")

--- a/src/main/java/fittering/mall/domain/entity/SubCategory.java
+++ b/src/main/java/fittering/mall/domain/entity/SubCategory.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -16,7 +17,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class SubCategory {
+public class SubCategory extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "sub_category_id")

--- a/src/main/java/fittering/mall/domain/entity/Top.java
+++ b/src/main/java/fittering/mall/domain/entity/Top.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
@@ -9,7 +10,7 @@ import static lombok.AccessLevel.PROTECTED;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class Top {
+public class Top extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "top_id")

--- a/src/main/java/fittering/mall/domain/entity/User.java
+++ b/src/main/java/fittering/mall/domain/entity/User.java
@@ -1,6 +1,7 @@
 package fittering.mall.domain.entity;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import jakarta.validation.constraints.Email;
 import lombok.AllArgsConstructor;
@@ -22,7 +23,7 @@ import static jakarta.persistence.FetchType.*;
 @Getter
 @Builder
 @AllArgsConstructor
-public class User {
+public class User extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "user_id")

--- a/src/main/java/fittering/mall/domain/entity/UserRecommendation.java
+++ b/src/main/java/fittering/mall/domain/entity/UserRecommendation.java
@@ -1,11 +1,10 @@
 package fittering.mall.domain.entity;
 
+import fittering.mall.domain.BaseEntity;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-
-import java.time.LocalDateTime;
 
 import static jakarta.persistence.FetchType.LAZY;
 import static lombok.AccessLevel.*;
@@ -13,7 +12,7 @@ import static lombok.AccessLevel.*;
 @Entity
 @Getter
 @NoArgsConstructor(access = PROTECTED)
-public class UserRecommendation {
+public class UserRecommendation extends BaseEntity {
 
     @Id @GeneratedValue
     @Column(name = "user_recommendation_id")
@@ -27,12 +26,9 @@ public class UserRecommendation {
     @JoinColumn(name = "product_id")
     private Product product;
 
-    private LocalDateTime updatedAt;
-
     @Builder
-    public UserRecommendation(User user, Product product, LocalDateTime updatedAt) {
+    public UserRecommendation(User user, Product product) {
         this.user = user;
         this.product = product;
-        this.updatedAt = updatedAt;
     }
 }

--- a/src/main/java/fittering/mall/domain/mapper/MallMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/MallMapper.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.mapper;
 
+import fittering.mall.config.kafka.domain.dto.CrawledMallDto;
 import fittering.mall.domain.dto.controller.request.RequestMallDto;
 import fittering.mall.domain.dto.controller.request.RequestMallRankProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallDto;
@@ -22,6 +23,8 @@ public interface MallMapper {
     MallMapper INSTANCE = Mappers.getMapper(MallMapper.class);
 
     Mall toMall(MallDto mallDto);
+    @Mapping(target = "mallDto.id", ignore = true)
+    Mall toMall(CrawledMallDto mallDto);
     MallDto toMallDto(RequestMallDto requestMallDto);
     MallRankProductDto toMallRankProductDto(RequestMallRankProductDto requestMallRankProductDto);
     ResponseMallDto toResponseMallDto(Mall mall, Integer view);

--- a/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.mapper;
 
+import fittering.mall.config.kafka.domain.dto.CrawledProductDto;
 import fittering.mall.domain.dto.controller.request.RequestProductDetailDto;
 import fittering.mall.domain.entity.*;
 import org.mapstruct.Mapper;
@@ -22,6 +23,16 @@ public interface ProductMapper {
     })
     Product toProduct(RequestProductDetailDto requestProductDetailDto, Integer view, Integer timeView,
                       Category category, SubCategory subCategory, Mall mall);
+    @Mappings({
+            @Mapping(target = "id", ignore = true),
+            @Mapping(source = "crawledProductDto.name", target = "name"),
+            @Mapping(source = "crawledProductDto.url", target = "origin"),
+            @Mapping(source = "category", target = "category"),
+            @Mapping(source = "subCategory", target = "subCategory"),
+            @Mapping(source = "mall", target = "mall")
+    })
+    Product toProduct(CrawledProductDto crawledProductDto, String image, Integer view,
+                      Integer timeView, Category category, SubCategory subCategory, Mall mall);
     @Mapping(source = "productDescription", target = "url")
     ProductDescription toProductDescription(String productDescription);
 }

--- a/src/main/java/fittering/mall/domain/mapper/SizeMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/SizeMapper.java
@@ -1,5 +1,6 @@
 package fittering.mall.domain.mapper;
 
+import fittering.mall.config.kafka.domain.dto.CrawledSizeDto;
 import fittering.mall.domain.dto.controller.request.RequestBottomDto;
 import fittering.mall.domain.dto.controller.request.RequestDressDto;
 import fittering.mall.domain.dto.controller.request.RequestOuterDto;
@@ -19,6 +20,11 @@ public interface SizeMapper {
     SizeMapper INSTANCE = Mappers.getMapper(SizeMapper.class);
 
     Bottom toBottom(BottomDto bottomDto);
+    @Mappings({
+            @Mapping(source = "bottomDto.bottom_width", target = "bottomWidth"),
+            @Mapping(source = "bottomDto.hip_width", target = "hipWidth")
+    })
+    Bottom toBottom(CrawledSizeDto bottomDto);
     BottomDto toBottomDto(RequestBottomDto requestBottomDto);
     @Mappings({
         @Mapping(source = "favoriteCount", target = "favoriteCount"),
@@ -40,6 +46,12 @@ public interface SizeMapper {
     ResponseBottomDto toResponseBottomDto(BottomProductDto bottomProductDto);
     ResponseBottomSizeDto toResponseBottomSizeDto(BottomDto bottomDto);
     Dress toDress(DressDto dressDto);
+    @Mappings({
+            @Mapping(source = "dressDto.arm_hall", target = "armHall"),
+            @Mapping(source = "dressDto.sleeve_width", target = "sleeveWidth"),
+            @Mapping(source = "dressDto.bottom_width", target = "bottomWidth")
+    })
+    Dress toDress(CrawledSizeDto dressDto);
     DressDto toDressDto(RequestDressDto requestDressDto);
     @Mappings({
             @Mapping(source = "favoriteCount", target = "favoriteCount"),
@@ -61,6 +73,7 @@ public interface SizeMapper {
     ResponseDressDto toResponseDressDto(DressProductDto dressProductDto);
     ResponseDressSizeDto toResponseDressSizeDto(DressDto dressDto);
     Top toTop(TopDto topDto);
+    Top toTop(CrawledSizeDto topDto);
     TopDto toTopDto(RequestTopDto requestTopDto);
     @Mappings({
             @Mapping(source = "favoriteCount", target = "favoriteCount"),
@@ -82,6 +95,7 @@ public interface SizeMapper {
     ResponseTopDto toResponseTopDto(TopProductDto topProductDto);
     ResponseTopSizeDto toResponseTopSizeDto(TopDto topDto);
     Outer toOuter(OuterDto outerDto);
+    Outer toOuter(CrawledSizeDto outerDto);
     OuterDto toOuterDto(RequestOuterDto requestOuterDto);
     @Mappings({
             @Mapping(source = "favoriteCount", target = "favoriteCount"),

--- a/src/main/java/fittering/mall/repository/ProductRepository.java
+++ b/src/main/java/fittering/mall/repository/ProductRepository.java
@@ -11,4 +11,5 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     @Override
     @EntityGraph(attributePaths = {"mall", "category"})
     Optional<Product> findById(Long productId);
+    Optional<Product> findByName(String name);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -8,6 +8,7 @@ import fittering.mall.domain.dto.service.TopProductDto;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
+import java.time.LocalDateTime;
 import java.util.List;
 
 public interface ProductRepositoryCustom {
@@ -29,4 +30,5 @@ public interface ProductRepositoryCustom {
     Long findRecentRecommendation(Long recentRecommendationId);
     Long findUserRecommendation(Long userRecommendationId);
     List<ResponseProductPreviewDto> timeRank(String gender);
+    LocalDateTime maxUpdatedAt();
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import fittering.mall.domain.entity.*;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -575,6 +576,14 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .orderBy(product.timeView.desc())
                 .limit(TIME_RANK_PRODUCT_COUNT)
                 .fetch();
+    }
+
+    @Override
+    public LocalDateTime maxUpdatedAt() {
+        return queryFactory
+                .select(product.updatedAt.max())
+                .from(product)
+                .fetchOne();
     }
 
     public OrderSpecifier<? extends Number> filter(Long filterId) {

--- a/src/main/java/fittering/mall/scheduler/CrawlingScheduler.java
+++ b/src/main/java/fittering/mall/scheduler/CrawlingScheduler.java
@@ -1,0 +1,21 @@
+package fittering.mall.scheduler;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import fittering.mall.config.kafka.KafkaProducer;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class CrawlingScheduler {
+
+    private final KafkaProducer kafkaProducer;
+
+    private final int TWO_WEEK = 1000 * 60 * 60 * 24 * 14;
+
+    @Scheduled(fixedDelay = TWO_WEEK)
+    public void updateCrawledProducts() throws JsonProcessingException {
+        kafkaProducer.callCrawledProductCountAPI();
+    }
+}

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -171,7 +171,6 @@ public class ProductService {
         return userRecommendationRepository.save(UserRecommendation.builder()
                                                     .user(user)
                                                     .product(product)
-                                                    .updatedAt(LocalDateTime.now())
                                                     .build());
     }
 
@@ -209,5 +208,9 @@ public class ProductService {
 
     public List<ResponseProductPreviewDto> productsOfTimeRank(String gender) {
         return productRepository.timeRank(gender);
+    }
+
+    public LocalDateTime productsOfMaxUpdatedAt() {
+        return productRepository.maxUpdatedAt();
     }
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -11,6 +11,7 @@ import fittering.mall.domain.mapper.SizeMapper;
 import jakarta.persistence.NoResultException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
@@ -47,6 +48,9 @@ public class ProductService {
     private final BottomRepository bottomRepository;
     private final RedisService redisService;
     private final S3Service s3Service;
+
+    @Value("${cloud.aws.cloudfront.url}")
+    private String CLOUDFRONT_URL;
 
     @Transactional
     public Product save(Product product) {
@@ -209,7 +213,7 @@ public class ProductService {
         List<ProductDescription> result = new ArrayList<>();
         productDescriptions.forEach(productDescriptionUrl -> {
             ProductDescription productDescription = ProductDescription.builder()
-                                                    .url(productDescriptionUrl)
+                                                    .url(CLOUDFRONT_URL + productDescriptionUrl)
                                                     .product(product)
                                                     .build();
             result.add(productDescriptionRepository.save(productDescription));
@@ -250,7 +254,7 @@ public class ProductService {
         Mall mall = mallRepository.findById(productDto.getMall_id())
                 .orElse(mallRepository.save(MallMapper.INSTANCE.toMall(mallDto)));
 
-        String thumbnail = imagePaths.get(0);
+        String thumbnail = CLOUDFRONT_URL + imagePaths.get(0);
         Product product = save(ProductMapper.INSTANCE.toProduct(
                 productDto, thumbnail, 0, 0, category, subCategory, mall));
 

--- a/src/main/java/fittering/mall/service/S3Service.java
+++ b/src/main/java/fittering/mall/service/S3Service.java
@@ -22,6 +22,7 @@ import static java.nio.charset.StandardCharsets.*;
 public class S3Service {
 
     private final AmazonS3 amazonS3;
+    private static final String IMAGE_CONTENT_TYPE = "image/*";
 
     @Value("${cloud.aws.s3.bucket.crawling}")
     private String crawlingBucket;
@@ -40,7 +41,7 @@ public class S3Service {
 
         InputStream fileInputStream = new ByteArrayInputStream(fileBytes);
         ObjectMetadata metadata = new ObjectMetadata();
-        metadata.setContentType("image/*");
+        metadata.setContentType(IMAGE_CONTENT_TYPE);
         metadata.setContentLength(fileBytes.length);
         amazonS3.putObject(serverBucket, fileName, fileInputStream, metadata);
     }

--- a/src/main/java/fittering/mall/service/S3Service.java
+++ b/src/main/java/fittering/mall/service/S3Service.java
@@ -1,0 +1,47 @@
+package fittering.mall.service;
+
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.model.GetObjectRequest;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.S3ObjectInputStream;
+import com.amazonaws.util.IOUtils;
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLEncoder;
+
+import static java.nio.charset.StandardCharsets.*;
+
+@Service
+@RequiredArgsConstructor
+public class S3Service {
+
+    private final AmazonS3 amazonS3;
+
+    @Value("${cloud.aws.s3.bucket.crawling}")
+    private String crawlingBucket;
+
+    @Value("${cloud.aws.s3.bucket.server}")
+    private String serverBucket;
+
+    public void moveS3ObjectToServerBucket(String storedFileName) throws IOException {
+        S3Object o = amazonS3.getObject(new GetObjectRequest(crawlingBucket, storedFileName));
+        S3ObjectInputStream objectInputStream = o.getObjectContent();
+        byte[] fileBytes = IOUtils.toByteArray(objectInputStream);
+        String fileName = URLEncoder.encode(storedFileName, UTF_8)
+                .replaceAll("\\+", "%20")
+                .replaceAll("%3A", ":")
+                .replaceAll("%5F", "_");
+
+        InputStream fileInputStream = new ByteArrayInputStream(fileBytes);
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType("image/*");
+        metadata.setContentLength(fileBytes.length);
+        amazonS3.putObject(serverBucket, fileName, fileInputStream, metadata);
+    }
+}

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -3,7 +3,13 @@
         <destination>127.0.0.1:4560</destination>
         <encoder class="net.logstash.logback.encoder.LogstashEncoder"></encoder>
     </appender>
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} %-5level [%thread] %logger - %msg%n</pattern>
+        </encoder>
+    </appender>
     <root level="INFO">
         <appender-ref ref="LOGSTASH"/>
+        <appender-ref ref="CONSOLE"/>
     </root>
 </configuration>

--- a/src/test/java/fittering/mall/service/FavoriteServiceTest.java
+++ b/src/test/java/fittering/mall/service/FavoriteServiceTest.java
@@ -95,6 +95,7 @@ class FavoriteServiceTest {
                                                 .category(category)
                                                 .subCategory(subCategory)
                                                 .mall(mall)
+                                                .disabled(0)
                                                 .build());
         Product product2 = productService.save(Product.builder()
                                                 .price(10000)
@@ -108,6 +109,7 @@ class FavoriteServiceTest {
                                                 .category(category)
                                                 .subCategory(subCategory)
                                                 .mall(mall)
+                                                .disabled(0)
                                                 .build());
         Product product3 = productService.save(Product.builder()
                                                 .price(10000)
@@ -121,6 +123,7 @@ class FavoriteServiceTest {
                                                 .category(category)
                                                 .subCategory(subCategory)
                                                 .mall(mall)
+                                                .disabled(0)
                                                 .build());
 
         List<ProductDescription> descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));

--- a/src/test/java/fittering/mall/service/MallServiceTest.java
+++ b/src/test/java/fittering/mall/service/MallServiceTest.java
@@ -63,6 +63,7 @@ class MallServiceTest {
                 .category(category)
                 .subCategory(subCategory)
                 .mall(mall1)
+                .disabled(0)
                 .build());
         List<ProductDescription> descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
 

--- a/src/test/java/fittering/mall/service/ProductServiceTest.java
+++ b/src/test/java/fittering/mall/service/ProductServiceTest.java
@@ -76,6 +76,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product2 = productService.save(Product.builder()
                 .price(10000)
@@ -89,6 +90,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product3 = productService.save(Product.builder()
                 .price(10000)
@@ -102,6 +104,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product4 = productService.save(Product.builder()
                 .price(10000)
@@ -115,6 +118,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product5 = productService.save(Product.builder()
                 .price(10000)
@@ -128,6 +132,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
         descImgs2 = List.of(new ProductDescription(descImgsStr.get(0), product2));
@@ -183,6 +188,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         Product topProduct2 = productService.save(Product.builder()
                 .price(10000)
@@ -196,6 +202,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         Product bottomProduct = productService.save(Product.builder()
                 .price(10000)
@@ -209,6 +216,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         Product bottomProduct2 = productService.save(Product.builder()
                 .price(10000)
@@ -222,6 +230,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         Product bottomProduct3 = productService.save(Product.builder()
                 .price(10000)
@@ -235,6 +244,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         Product bottomProduct4 = productService.save(Product.builder()
                 .price(10000)
@@ -248,6 +258,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> topDescriptionImgs = List.of(new ProductDescription(descImgsStr.get(0), topProduct));
         List<ProductDescription> topDescriptionImgs2 = List.of(new ProductDescription(descImgsStr.get(0), topProduct2));
@@ -275,6 +286,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         Product topProduct2 = productService.save(Product.builder()
                 .price(10000)
@@ -288,6 +300,7 @@ class ProductServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> topDescriptionImgs = List.of(new ProductDescription(descImgsStr.get(0), topProduct));
         List<ProductDescription> topDescriptionImgs2 = List.of(new ProductDescription(descImgsStr.get(0), topProduct2));
@@ -305,6 +318,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall2)
+                .disabled(0)
                 .build());
         Product bottomProduct2 = productService.save(Product.builder()
                 .price(10000)
@@ -318,6 +332,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall2)
+                .disabled(0)
                 .build());
         Product bottomProduct3 = productService.save(Product.builder()
                 .price(10000)
@@ -331,6 +346,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall2)
+                .disabled(0)
                 .build());
         Product bottomProduct4 = productService.save(Product.builder()
                 .price(10000)
@@ -344,6 +360,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall2)
+                .disabled(0)
                 .build());
         List<ProductDescription> bottomDescriptionImgs = List.of(new ProductDescription(descImgsStr.get(0), bottomProduct));
         List<ProductDescription> bottomDescriptionImgs2 = List.of(new ProductDescription(descImgsStr.get(0), bottomProduct2));
@@ -418,6 +435,7 @@ class ProductServiceTest {
                 .category(bottomCategory)
                 .subCategory(bottomSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> bottomDescriptionImgs = List.of(new ProductDescription(descImgsStr.get(0), bottomProduct));
 

--- a/src/test/java/fittering/mall/service/RankServiceTest.java
+++ b/src/test/java/fittering/mall/service/RankServiceTest.java
@@ -70,6 +70,7 @@ class RankServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product2 = productService.save(Product.builder()
                 .price(10000)
@@ -83,6 +84,7 @@ class RankServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product3 = productService.save(Product.builder()
                 .price(10000)
@@ -96,6 +98,7 @@ class RankServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product4 = productService.save(Product.builder()
                 .price(10000)
@@ -109,6 +112,7 @@ class RankServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall2)
+                .disabled(0)
                 .build());
         descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
         descImgs2 = List.of(new ProductDescription(descImgsStr.get(0), product2));

--- a/src/test/java/fittering/mall/service/SearchServiceTest.java
+++ b/src/test/java/fittering/mall/service/SearchServiceTest.java
@@ -73,6 +73,7 @@ class SearchServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product2 = productService.save(Product.builder()
                 .price(10000)
@@ -86,6 +87,7 @@ class SearchServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product3 = productService.save(Product.builder()
                 .price(10000)
@@ -99,6 +101,7 @@ class SearchServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         product4 = productService.save(Product.builder()
                 .price(10000)
@@ -112,6 +115,7 @@ class SearchServiceTest {
                 .category(topCategory)
                 .subCategory(topSubCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
         descImgs2 = List.of(new ProductDescription(descImgsStr.get(0), product2));

--- a/src/test/java/fittering/mall/service/SizeServiceTest.java
+++ b/src/test/java/fittering/mall/service/SizeServiceTest.java
@@ -54,6 +54,7 @@ class SizeServiceTest {
                 .category(category)
                 .subCategory(subCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
 
@@ -88,6 +89,7 @@ class SizeServiceTest {
                 .category(category)
                 .subCategory(subCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
 
@@ -122,6 +124,7 @@ class SizeServiceTest {
                 .category(category)
                 .subCategory(subCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
 

--- a/src/test/java/fittering/mall/service/UserServiceTest.java
+++ b/src/test/java/fittering/mall/service/UserServiceTest.java
@@ -85,6 +85,7 @@ class UserServiceTest {
                 .category(category)
                 .subCategory(subCategory)
                 .mall(mall)
+                .disabled(0)
                 .build());
         List<ProductDescription> descImgs = List.of(new ProductDescription(descImgsStr.get(0), product));
     }


### PR DESCRIPTION
## Kafka 적용
### 생성일, 최종 수정일 필드 추가
생성일 `created_at`, 최종 수정일 `updated_at` 필드를 모든 테이블에 추가했습니다. 해당 내용은 `BaseEntity`에 설정했습니다.
상품 엔티티 `Product`에서 `updated_at`의 최댓값은 **크롤링 DB에서 가져오는 상품 기준으로 활용됩니다.**
```java
public class BaseEntity {

    @CreatedDate
    @Column(updatable = false, name = "created_at")
    private LocalDateTime createdAt;

    @LastModifiedDate
    @Column(name = "updated_at")
    private LocalDateTime updatedAt;
}

//상속해서 필드 추가
public class Product extends BaseEntity { ... }
```
- [feat: 모든 엔티티에 생성 날짜, 최종 업데이트 날짜 필드 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/c41b52d500bd6fe17798161ecc4b556af83fb16b)

### Kafka
프로젝트에 Kafka를 적용해 DB 간 데이터 동기화를 수행하는데 활용합니다.
서비스에서 직접적으로 사용하는 운영 DB와 크롤링 상품을 담는 크롤링 DB에서 차이가 없도록 **2주**마다 동기화 처리를 수행합니다.
크롤링 DB에서 가져올 상품들은 ML 서버에서 구현된 API를 통해 가져오게 되며 새 상품은 **신규 등록**을, 기존 상품은 **가격 및 비활성화 여부를 업데이트**합니다.
```java
@Component
@RequiredArgsConstructor
public class CrawlingScheduler {

    private final KafkaProducer kafkaProducer;

    private final int TWO_WEEK = 1000 * 60 * 60 * 24 * 14;

    @Scheduled(fixedDelay = TWO_WEEK) //2주마다 호출
    public void updateCrawledProducts() throws JsonProcessingException {
        //ML 서버 API를 호출해 크롤링 상품 정보를 얻는 API를 호출
        //얻은 상품 정보들을 운영 DB에 초기화까지 한 번에 수행
        kafkaProducer.callCrawledProductCountAPI();
    }
}
```
- 팀 내 회의를 통해 업데이트 주기를 **2주**로 설정
- 📄 : [[Spring] Kafka 적용하기](https://yooniversal.github.io/project/post259/)
- [feat: Kafka로 크롤링/운영 DB 간 동기화 로직 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/6d1f28123d9abafa44dd88b09098b138e632c05e)
- [feat: 스케쥴러에 DB 동기화 메소드 등록](https://github.com/YeolJyeongKong/fittering-BE/commit/389e19fe5d26d4ddab0782bad8beae711a79bc7d)

### S3 객체 이동
크롤링한 상품이 저장되는 S3 버킷은 서비스에서 활용할 S3 버킷과 다릅니다.
때문에 서비스용 S3 버킷에 크롤링 상품 정보를 옮겨주는 작업이 필요해 S3에 접근할 수 있도록 설정 클래스 추가 후 옮기는 로직을 적용했습니다.
- 📄 : [[Spring] AWS S3에 저장된 파일 다운로드/업로드 구현](https://yooniversal.github.io/project/post258/)
- [feat: S3 의존성 및 설정 클래스 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/ba9e5d5b5f1947f3d6468e4ed3d248830747cceb)
- [feat: S3 서비스 로직 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/7980ad9e6acb574f72f35c590c3c1662445cf6e8)

ML 서버 API를 통해 가져오는 상품 정보는 **웹 배포된 URI가 아니기 때문에** 
프론트에서 활용할 수 있도록 웹 배포된 URI로 전처리 후 DB에 저장됩니다.

`CLOUDFRONT_URL`는 AWS CloudFront를 통해 웹 배포된 URI를, `productDescriptionUrl`는 S3 경로를 의미합니다.
- Before : `productDescriptionUrl`
- After : **CLOUDFRONT_URL** + `productDescriptionUrl`
- [fix: 웹 배포 URL을 DB에 저장하도록 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/a978afe0167203405db10099100c07724b77c002)