### PR TITLE
버그 수정 : 상품 등록 API 예외 발생 - NullPointerException

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -58,7 +58,7 @@ public class ProductController {
         SubCategory subCategory = categoryService.findByNameOfSubCategory(requestProductDto.getSubCategoryName());
         Mall mall = mallService.findByName(requestProductDto.getMallName());
         Product product = productService.save(ProductMapper.INSTANCE.toProduct(
-                requestProductDto, 0, 0, category, subCategory, mall));
+                requestProductDto, 0, 0, category, subCategory, mall, 0));
         productService.saveProductDescription(requestProductDto.getProductDescriptions(), product);
 
         if (requestProductDto.getType().equals(OUTER)) {

--- a/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
@@ -22,14 +22,15 @@ public interface ProductMapper {
             @Mapping(source = "mall", target = "mall")
     })
     Product toProduct(RequestProductDetailDto requestProductDetailDto, Integer view, Integer timeView,
-                      Category category, SubCategory subCategory, Mall mall);
+                      Category category, SubCategory subCategory, Mall mall, Integer disabled);
     @Mappings({
             @Mapping(target = "id", ignore = true),
             @Mapping(source = "crawledProductDto.name", target = "name"),
             @Mapping(source = "crawledProductDto.url", target = "origin"),
             @Mapping(source = "category", target = "category"),
             @Mapping(source = "subCategory", target = "subCategory"),
-            @Mapping(source = "mall", target = "mall")
+            @Mapping(source = "mall", target = "mall"),
+            @Mapping(source = "disabled", target = "disabled"),
     })
     Product toProduct(CrawledProductDto crawledProductDto, String image, Integer view,
                       Integer timeView, Category category, SubCategory subCategory, Mall mall);


### PR DESCRIPTION
## 버그 수정
### 상품 등록 API 호출 시 예외 발생
> 17:23:44.131 ERROR [http-nio-8080-exec-8] org.apache.catalina.core.ContainerBase.[Tomcat].[localhost].[/].[dispatcherServlet] - Servlet.service() for servlet [dispatcherServlet] in context with path [] threw exception [Request processing failed: java.lang.NullPointerException: disabled is marked non-null but is null] with root cause
java.lang.NullPointerException: disabled is marked non-null but is null
	at fittering.mall.domain.entity.Product.<init>(Product.java:18)
	at fittering.mall.domain.entity.Product$ProductBuilder.build(Product.java:17)
	at fittering.mall.domain.mapper.ProductMapperImpl.toProduct(ProductMapperImpl.java:51)
	at fittering.mall.controller.ProductController.save(ProductController.java:60)

#80 에서 DB 간 동기화를 할 때 **상품 비활성화 여부**가 업데이트 대상이어서 `Product`에 `disabled` 필드 추가했었습니다.
하지만 `disabled`에 대해서 상품 등록 API를 사용해 새 상품을 추가할 때 초기화할 수 있도록 별도로 처리해주지 않아 에러가 발생했습니다.

API를 통해 새 상품을 등록하는 경우 반드시 `disabled`가 **0**이므로 상품 요청 DTO인 `RequestProductDetailDto`에 `disabled`를 추가하지 않고, MapStruct 파라미터에 직접 해당 정보를 입력했습니다. 이 때, `disabled`는 type이 Integer이므로 `false`가 아닌 `0`로 등록됩니다.
```java
@PostMapping("/auth/products")
public ResponseEntity<?> save(@RequestBody @Valid RequestProductDetailDto requestProductDto,
                              BindingResult bindingResult) {
    ...
    //마지막 파라미터 == disabled
    //0으로 초기화
    Product product = productService.save(ProductMapper.INSTANCE.toProduct(
            requestProductDto, 0, 0, category, subCategory, mall, 0));
    productService.saveProductDescription(requestProductDto.getProductDescriptions(), product);
    ...
}
```
- [fix: API로 상품 등록 시 disabled 필드 초기화](https://github.com/YeolJyeongKong/fittering-BE/commit/3bd47fce501f5859ab6d90abc26bf837345ed081)