### PR TITLE
버그 수정 : 상품 상세 조회 시 SerializationException 발생

### DIFF
--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -57,7 +57,6 @@ public class ProductService {
         return productRepository.save(product);
     }
 
-    @Cacheable(value = "Product", key = "#productId")
     public Product findById(Long productId) {
         return productRepository.findById(productId)
                 .orElseThrow(() -> new NoResultException("product dosen't exist"));


### PR DESCRIPTION
## 버그 수정
### 상품 상세 조회 예외 발생 : SerializationException
> org.springframework.data.redis.serializer.SerializationException: Could not read JSON:failed to lazily initialize a collection: could not initialize proxy - no Session (through reference chain: fittering.mall.domain.entity.Product["recents"]) ] with root cause
org.hibernate.LazyInitializationException: failed to lazily initialize a collection: could not initialize proxy - no Session
        at 
...
        at fittering.mall.service.ProductService$$SpringCGLIB$$0.findById(<generated>)
        at fittering.mall.controller.ProductController.productDetail(ProductController.java:166)

상품 상세 조회 API에서 캐싱된 내용을 가져올 때 즉, 2번째 호출부터 `SerializationException`가 발생했고, 첫 호출 시 Redis 캐시에 저장한 내용을 응답으로 보낼 때 **역직렬화**를 거치게 되는데 이 과정에서 적절하게 처리되지 않아 문제가 발생하는 것으로 판단했습니다.

상품 상세 조회 시 현재 유저의 **즐겨찾기 여부 정보**를 렌더링할 수 있도록 응답에 **`isFavorite`를 추가**할 예정입니다.
때문에 해당 API에서는 **캐싱을 하지 않아야 하므로** `findById()`에서 `@Cacheable`를 제거해 캐싱하지 않도록 설정했습니다.
```java
// 캐싱 해제
// @Cacheable(value = "Product", key = "#productId")
public Product findById(Long productId) {
    return productRepository.findById(productId)
            .orElseThrow(() -> new NoResultException("product dosen't exist"));
}
```
- [fix: 상품 조회 메소드 findById() 캐시 적용 해제](https://github.com/YeolJyeongKong/fittering-BE/commit/ea03badbf671793958fe25919fa13cbb76480170)