### PR TITLE
API 수정 : 응답에 즐겨찾기 여부 정보 추가

### DIFF
--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -59,7 +59,7 @@ public class MallController {
     @GetMapping("/malls/{mallId}")
     public ResponseEntity<?> mallRank(@PathVariable("mallId") @NotEmpty Long mallId,
                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
-        ResponseMallDto responseMallDto = mallService.findById(mallId);
+        ResponseMallDto responseMallDto = mallService.findById(principalDetails.getUser().getId(), mallId);
         rankService.updateViewOnMall(principalDetails.getUser().getId(), mallId);
         return new ResponseEntity<>(responseMallDto, HttpStatus.OK);
     }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallDto.java
@@ -15,4 +15,5 @@ public class ResponseMallDto {
     private String url;
     private String image;
     private String description;
+    private Boolean isFavorite;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallPreviewDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallPreviewDto.java
@@ -13,4 +13,5 @@ public class ResponseMallPreviewDto {
     private Long id;
     private String name;
     private String image;
+    private Boolean isFavorite;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallWithProductDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallWithProductDto.java
@@ -17,5 +17,6 @@ public class ResponseMallWithProductDto {
     private String image;
     private String description;
     private Integer view;
+    private Boolean isFavorite;
     private List<ResponseMallRankProductDto> products;
 }

--- a/src/main/java/fittering/mall/domain/mapper/MallMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/MallMapper.java
@@ -27,9 +27,9 @@ public interface MallMapper {
     Mall toMall(CrawledMallDto mallDto);
     MallDto toMallDto(RequestMallDto requestMallDto);
     MallRankProductDto toMallRankProductDto(RequestMallRankProductDto requestMallRankProductDto);
-    ResponseMallDto toResponseMallDto(Mall mall, Integer view);
+    ResponseMallDto toResponseMallDto(Mall mall, Integer view, Boolean isFavorite);
     @Mapping(source = "products", target = "products")
-    ResponseMallWithProductDto toResponseMallWithProductDto(Mall mall, List<ResponseMallRankProductDto> products, Integer view);
+    ResponseMallWithProductDto toResponseMallWithProductDto(Mall mall, List<ResponseMallRankProductDto> products, Integer view, Boolean isFavorite);
     MallPreviewDto toMallPreviewDto(SavedMallPreviewDto savedMallPreviewDto);
-    ResponseMallPreviewDto toResponseMallPreviewDto(MallPreviewDto mallPreviewDto);
+    ResponseMallPreviewDto toResponseMallPreviewDto(MallPreviewDto mallPreviewDto, Boolean isFavorite);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
+++ b/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
@@ -61,6 +61,18 @@ public class EqualMethod {
         return favoriteId != null ? favorite.id.eq(favoriteId) : null;
     }
 
+    public static BooleanExpression favoriteUserIdEq(Long userId) {
+        return userId != null ? favorite.user.id.eq(userId) : null;
+    }
+
+    public static BooleanExpression favoriteMallIdEq(Long mallId) {
+        return mallId != null ? favorite.mall.id.eq(mallId) : null;
+    }
+
+    public static BooleanExpression favoriteProductIdEq(Long productId) {
+        return productId != null ? favorite.product.id.eq(productId) : null;
+    }
+
     public static BooleanExpression recentRecommendationIdEq(Long recentRecommendationId) {
         return recentRecommendationId != null ? recentRecommendation.id.eq(recentRecommendationId) : null;
     }

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryCustom.java
@@ -13,4 +13,5 @@ public interface FavoriteRepositoryCustom {
     List<ResponseProductPreviewDto> userFavoriteProductPreview(Long userId);
     void deleteByUserIdAndMallId(Long userId, Long mallId);
     void deleteByUserIdAndProductId(Long userId, Long productId);
+    Boolean isUserFavoriteMall(Long userId, Long mallId);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
@@ -15,7 +15,7 @@ import static fittering.mall.domain.entity.QFavorite.favorite;
 import static fittering.mall.domain.entity.QMall.mall;
 import static fittering.mall.domain.entity.QProduct.product;
 import static fittering.mall.domain.entity.QUser.user;
-import static fittering.mall.repository.querydsl.EqualMethod.userIdEq;
+import static fittering.mall.repository.querydsl.EqualMethod.*;
 
 public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
 
@@ -107,7 +107,10 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
     public void deleteByUserIdAndMallId(Long userId, Long mallId) {
         queryFactory
                 .delete(favorite)
-                .where(favorite.user.id.eq(userId).and(favorite.mall.id.eq(mallId)))
+                .where(
+                        favoriteUserIdEq(userId),
+                        favoriteMallIdEq(mallId)
+                )
                 .execute();
     }
 
@@ -115,7 +118,24 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
     public void deleteByUserIdAndProductId(Long userId, Long productId) {
         queryFactory
                 .delete(favorite)
-                .where(favorite.user.id.eq(userId).and(favorite.product.id.eq(productId)))
+                .where(
+                        favoriteUserIdEq(userId),
+                        favoriteProductIdEq(productId)
+                )
                 .execute();
+    }
+
+    @Override
+    public Boolean isUserFavoriteMall(Long userId, Long mallId) {
+        Long count = queryFactory
+                .select(favorite.count())
+                .from(favorite)
+                .where(
+                        favoriteUserIdEq(userId),
+                        favoriteMallIdEq(mallId)
+                )
+                .fetchOne();
+
+        return count != null && count > 0;
     }
 }

--- a/src/main/java/fittering/mall/service/FavoriteService.java
+++ b/src/main/java/fittering/mall/service/FavoriteService.java
@@ -57,7 +57,7 @@ public class FavoriteService {
                                                     .build());
             }
 
-            result.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, 0));
+            result.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, 0, true));
         });
         return result;
     }

--- a/src/main/java/fittering/mall/service/MallService.java
+++ b/src/main/java/fittering/mall/service/MallService.java
@@ -3,6 +3,7 @@ package fittering.mall.service;
 import fittering.mall.domain.dto.controller.response.ResponseMallDto;
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
 import fittering.mall.domain.mapper.MallMapper;
+import fittering.mall.repository.FavoriteRepository;
 import jakarta.persistence.NoResultException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -21,15 +22,17 @@ public class MallService {
 
     private final MallRepository mallRepository;
     private final ProductRepository productRepository;
+    private final FavoriteRepository favoriteRepository;
 
     public Mall save(MallDto mallDto) {
         return mallRepository.save(MallMapper.INSTANCE.toMall(mallDto));
     }
 
-    public ResponseMallDto findById(Long mallId) {
+    public ResponseMallDto findById(Long userId, Long mallId) {
         Mall mall = mallRepository.findById(mallId)
                 .orElseThrow(() -> new NoResultException("mall dosen't exist"));
-        return MallMapper.INSTANCE.toResponseMallDto(mall, 0);
+        Boolean isFavorite = favoriteRepository.isUserFavoriteMall(userId, mallId);
+        return MallMapper.INSTANCE.toResponseMallDto(mall, 0, isFavorite);
     }
 
     public Mall findByName(String mallName) {

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -4,6 +4,7 @@ import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallPreviewDto;
 import fittering.mall.domain.dto.controller.response.ResponseMallRankProductDto;
 import fittering.mall.domain.mapper.MallMapper;
+import fittering.mall.repository.*;
 import jakarta.persistence.NoResultException;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
@@ -11,10 +12,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import fittering.mall.domain.dto.service.MallPreviewDto;
 import fittering.mall.domain.entity.*;
-import fittering.mall.repository.MallRepository;
-import fittering.mall.repository.ProductRepository;
-import fittering.mall.repository.RankRepository;
-import fittering.mall.repository.UserRepository;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -31,6 +28,7 @@ public class RankService {
     private final MallRepository mallRepository;
     private final RankRepository rankRepository;
     private final ProductRepository productRepository;
+    private final FavoriteRepository favoriteRepository;
     private final RedisService redisService;
 
     @Transactional
@@ -72,7 +70,8 @@ public class RankService {
                                                     .build());
             }
 
-            result.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, rank.getView()));
+            Boolean isFavorite = favoriteRepository.isUserFavoriteMall(userId, mall.getId());
+            result.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, rank.getView(), isFavorite));
         });
         return result;
     }
@@ -81,7 +80,8 @@ public class RankService {
         List<MallPreviewDto> mallPreviewDtos = rankRepository.mallRankPreview(userId, pageable, count);
         List<ResponseMallPreviewDto> result = new ArrayList<>();
         mallPreviewDtos.forEach(mallPreviewDto -> {
-            result.add(MallMapper.INSTANCE.toResponseMallPreviewDto(mallPreviewDto));
+            Boolean isFavorite = favoriteRepository.isUserFavoriteMall(userId, mallPreviewDto.getId());
+            result.add(MallMapper.INSTANCE.toResponseMallPreviewDto(mallPreviewDto, isFavorite));
         });
         return result;
     }


### PR DESCRIPTION
## API 수정
### 응답에 즐겨찾기 여부 정보 추가
다음 3가지 API에서 응답에 `isFavorite`을 추가해 **사용자가 쇼핑몰 페이지에 접근했을 때 즐겨찾기 했는지 여부**를 알 수 있도록 했습니다.
기존 API 스펙에는 해당 정보를 의미하는 필드가 없어 응답 필드를 추가했습니다.

다음은 수정한 API 3개입니다.
- 쇼핑몰 랭킹 조회 (미리보기, 상세(웹/모바일))
- 쇼핑몰 상세 조회
- 즐겨찾기 쇼핑몰 상세 조회
<br>

다음은 수정한 DTO 정보입니다.
`isFavorite` 필드를 추가한걸 확인할 수 있으며, 이외에 수정된 DTO는 `ResponseMallPreviewDto`, `ResponseMallWithProductDto`가 있습니다.
```java
public class ResponseMallDto {
    private Long id;
    private String name;
    private String url;
    private String image;
    private String description;
    private Boolean isFavorite; //추가
}
```
- [feat: DTO에 isFavorite 필드 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/cf0a543d657e8f692e73bbf9911f2ed998a8ede9)
- [feat: isFavorite 필드 정보 얻는 쿼리 작성](https://github.com/YeolJyeongKong/fittering-BE/commit/d9b7963a367a212e6bbf9a795b045da27da1cdc7)
- [feat: API 응답으로 isFavorite 반환](https://github.com/YeolJyeongKong/fittering-BE/commit/30238ee644c6acbc0ee09320e1c7cd5083ba77a3)