### PR TITLE
API 수정 : 상품 상세조회 시 즐겨찾기 여부 정보 추가

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -166,22 +166,22 @@ public class ProductController {
         userService.saveRecentProduct(principalDetails.getUser().getId(), productId);
 
         if(product.getType().equals(OUTER)) {
-            ResponseOuterDto outerProduct = productService.outerProductDetail(productId);
+            ResponseOuterDto outerProduct = productService.outerProductDetail(principalDetails.getUser().getId(), productId);
             return new ResponseEntity<>(outerProduct, HttpStatus.OK);
         }
 
         if(product.getType().equals(TOP)) {
-            ResponseTopDto topProduct = productService.topProductDetail(productId);
+            ResponseTopDto topProduct = productService.topProductDetail(principalDetails.getUser().getId(), productId);
             return new ResponseEntity<>(topProduct, HttpStatus.OK);
         }
 
         if(product.getType().equals(DRESS)) {
-            ResponseDressDto dressProduct = productService.dressProductDetail(productId);
+            ResponseDressDto dressProduct = productService.dressProductDetail(principalDetails.getUser().getId(), productId);
             return new ResponseEntity<>(dressProduct, HttpStatus.OK);
         }
 
         if(product.getType().equals(BOTTOM)) {
-            ResponseBottomDto bottomProduct = productService.bottomProductDetail(productId);
+            ResponseBottomDto bottomProduct = productService.bottomProductDetail(principalDetails.getUser().getId(), productId);
             return new ResponseEntity<>(bottomProduct, HttpStatus.OK);
         }
 

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseBottomDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseBottomDto.java
@@ -26,6 +26,7 @@ public class ResponseBottomDto {
     private Integer view;
     private String popularGender;
     private Integer popularAgeRange;
+    private Boolean isFavorite;
     private List<ResponseBottomSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseDressDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseDressDto.java
@@ -26,6 +26,7 @@ public class ResponseDressDto {
     private Integer view;
     private String popularGender;
     private Integer popularAgeRange;
+    private Boolean isFavorite;
     private List<ResponseDressSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseOuterDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseOuterDto.java
@@ -26,6 +26,7 @@ public class ResponseOuterDto {
     private Integer view;
     private String popularGender;
     private Integer popularAgeRange;
+    private Boolean isFavorite;
     private List<ResponseOuterSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseTopDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseTopDto.java
@@ -26,6 +26,7 @@ public class ResponseTopDto {
     private Integer view;
     private String popularGender;
     private Integer popularAgeRange;
+    private Boolean isFavorite;
     private List<ResponseTopSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
 }

--- a/src/main/java/fittering/mall/domain/mapper/SizeMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/SizeMapper.java
@@ -45,7 +45,7 @@ public interface SizeMapper {
     })
     BottomProductDto toBottomProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<BottomDto> sizes);
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseBottomDto toResponseBottomDto(BottomProductDto bottomProductDto, List<ResponseProductDescriptionDto> productDescriptions);
+    ResponseBottomDto toResponseBottomDto(BottomProductDto bottomProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
     ResponseBottomSizeDto toResponseBottomSizeDto(BottomDto bottomDto);
     Dress toDress(DressDto dressDto);
     @Mappings({
@@ -74,7 +74,7 @@ public interface SizeMapper {
     })
     DressProductDto toDressProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<DressDto> sizes);
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseDressDto toResponseDressDto(DressProductDto dressProductDto, List<ResponseProductDescriptionDto> productDescriptions);
+    ResponseDressDto toResponseDressDto(DressProductDto dressProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
     ResponseDressSizeDto toResponseDressSizeDto(DressDto dressDto);
     Top toTop(TopDto topDto);
     Top toTop(CrawledSizeDto topDto);
@@ -98,7 +98,7 @@ public interface SizeMapper {
     })
     TopProductDto toTopProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<TopDto> sizes);
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseTopDto toResponseTopDto(TopProductDto topProductDto, List<ResponseProductDescriptionDto> productDescriptions);
+    ResponseTopDto toResponseTopDto(TopProductDto topProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
     ResponseTopSizeDto toResponseTopSizeDto(TopDto topDto);
     Outer toOuter(OuterDto outerDto);
     Outer toOuter(CrawledSizeDto outerDto);
@@ -123,6 +123,6 @@ public interface SizeMapper {
     OuterProductDto toOuterProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<OuterDto> sizes);
 
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseOuterDto toResponseOuterDto(OuterProductDto outerProductDto, List<ResponseProductDescriptionDto> productDescriptions);
+    ResponseOuterDto toResponseOuterDto(OuterProductDto outerProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
     ResponseOuterSizeDto toResponseOuterSizeDto(OuterDto outerDto);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryCustom.java
@@ -14,4 +14,5 @@ public interface FavoriteRepositoryCustom {
     void deleteByUserIdAndMallId(Long userId, Long mallId);
     void deleteByUserIdAndProductId(Long userId, Long productId);
     Boolean isUserFavoriteMall(Long userId, Long mallId);
+    Boolean isUserFavoriteProduct(Long userId, Long productId);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/FavoriteRepositoryImpl.java
@@ -138,4 +138,18 @@ public class FavoriteRepositoryImpl implements FavoriteRepositoryCustom {
 
         return count != null && count > 0;
     }
+
+    @Override
+    public Boolean isUserFavoriteProduct(Long userId, Long productId) {
+        Long count = queryFactory
+                .select(favorite.count())
+                .from(favorite)
+                .where(
+                        favoriteUserIdEq(userId),
+                        favoriteProductIdEq(productId)
+                )
+                .fetchOne();
+
+        return count != null && count > 0;
+    }
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -46,6 +46,7 @@ public class ProductService {
     private final TopRepository topRepository;
     private final DressRepository dressRepository;
     private final BottomRepository bottomRepository;
+    private final FavoriteRepository favoriteRepository;
     private final RedisService redisService;
     private final S3Service s3Service;
 
@@ -147,27 +148,31 @@ public class ProductService {
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
-    public ResponseOuterDto outerProductDetail(Long productId) {
+    public ResponseOuterDto outerProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
-        return SizeMapper.INSTANCE.toResponseOuterDto(productRepository.outerProductDetail(productId), productDescriptions);
+        Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
+        return SizeMapper.INSTANCE.toResponseOuterDto(productRepository.outerProductDetail(productId), productDescriptions, isFavorite);
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
-    public ResponseTopDto topProductDetail(Long productId) {
+    public ResponseTopDto topProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
-        return SizeMapper.INSTANCE.toResponseTopDto(productRepository.topProductDetail(productId), productDescriptions);
+        Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
+        return SizeMapper.INSTANCE.toResponseTopDto(productRepository.topProductDetail(productId), productDescriptions, isFavorite);
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
-    public ResponseDressDto dressProductDetail(Long productId) {
+    public ResponseDressDto dressProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
-        return SizeMapper.INSTANCE.toResponseDressDto(productRepository.dressProductDetail(productId), productDescriptions);
+        Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
+        return SizeMapper.INSTANCE.toResponseDressDto(productRepository.dressProductDetail(productId), productDescriptions, isFavorite);
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
-    public ResponseBottomDto bottomProductDetail(Long productId) {
+    public ResponseBottomDto bottomProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
-        return SizeMapper.INSTANCE.toResponseBottomDto(productRepository.bottomProductDetail(productId), productDescriptions);
+        Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
+        return SizeMapper.INSTANCE.toResponseBottomDto(productRepository.bottomProductDetail(productId), productDescriptions, isFavorite);
     }
 
     public void updateView(Long productId) {

--- a/src/test/java/fittering/mall/service/ProductServiceTest.java
+++ b/src/test/java/fittering/mall/service/ProductServiceTest.java
@@ -407,7 +407,7 @@ class ProductServiceTest {
 
     @Test
     void topProductDetail() {
-        ResponseTopDto topProductDto = productService.topProductDetail(product.getId());
+        ResponseTopDto topProductDto = productService.topProductDetail(user.getId(), product.getId());
         assertThat(topProductDto.getProductImage()).isEqualTo(product.getImage());
         assertThat(topProductDto.getProductName()).isEqualTo(product.getName());
         assertThat(topProductDto.getProductGender()).isEqualTo(product.getGender());
@@ -439,7 +439,7 @@ class ProductServiceTest {
                 .build());
         List<ProductDescription> bottomDescriptionImgs = List.of(new ProductDescription(descImgsStr.get(0), bottomProduct));
 
-        ResponseBottomDto bottomProductDto = productService.bottomProductDetail(bottomProduct.getId());
+        ResponseBottomDto bottomProductDto = productService.bottomProductDetail(user.getId(), bottomProduct.getId());
         assertThat(bottomProductDto.getProductImage()).isEqualTo(bottomProduct.getImage());
         assertThat(bottomProductDto.getProductName()).isEqualTo(bottomProduct.getName());
         assertThat(bottomProductDto.getProductGender()).isEqualTo(bottomProduct.getGender());


### PR DESCRIPTION
## API 수정
### 응답에 즐겨찾기 여부 정보 추가
상품 상세조회 API 응답에 `isFavorite`을 추가해 **사용자가 쇼핑몰 페이지에 접근했을 때 즐겨찾기 했는지 여부**를 알 수 있도록 했습니다.
기존 API 스펙에는 해당 정보를 의미하는 필드가 없어 응답 필드를 추가했습니다.
- #94 설명과 동일
- API URI : `/api/v1/auth/products/{productId}`
<br>

다음은 수정한 DTO 정보입니다.
`isFavorite` 필드를 추가한걸 확인할 수 있으며, 이외에 수정된 DTO는 `ResponseTopDto`, `ResponseDressDto`, `ResponseBottomDto`가 있습니다.
```java
public class ResponseOuterDto {
    ...
    private String popularGender;
    private Integer popularAgeRange;
    private Boolean isFavorite; //추가
    private List<ResponseOuterSizeDto> sizes;
    private List<ResponseProductDescriptionDto> descriptions;
}

```
- [feat: 상품 상세조회 DTO 즐겨찾기 여부 필드 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/fe3efe8f8714ed7a7e0789087ddab85660c793dd)
- [feat: 즐겨찾기 여부 쿼리 정의 및 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/eb1184769fbf54a6fc00ddf45af42db1c7d3780e)
<br>

### 캐싱 해제
상품 상세조회 시 빠른 로드를 위해 API에 캐싱을 적용했으나, `isFavorite`을 추가할 경우 즐겨찾기 갱신이 자주 이뤄지면 캐싱하는 의미가 없을거라고 판단해 해제했습니다.
```java
// @Cacheable(value = "ProductDetail", key = "#productId")
public ResponseBottomDto bottomProductDetail(Long userId, Long productId) {
    List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
    Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
    return SizeMapper.INSTANCE.toResponseBottomDto(productRepository.bottomProductDetail(productId), productDescriptions, isFavorite);
}
```
- [fix: 상세조회 API 캐싱 해제](https://github.com/YeolJyeongKong/fittering-BE/commit/005b3a586a25444adb365cd4e60c9d62ac7f3332)