### PR TITLE
API 수정 : 상품 상세조회 응답에 인기 정보 추가

### DIFF
--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseBottomDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseBottomDto.java
@@ -29,4 +29,6 @@ public class ResponseBottomDto {
     private Boolean isFavorite;
     private List<ResponseBottomSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
+    private List<Integer> popularAgeRangePercents;
+    private List<Integer> popularGenderPercents;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseDressDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseDressDto.java
@@ -29,4 +29,6 @@ public class ResponseDressDto {
     private Boolean isFavorite;
     private List<ResponseDressSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
+    private List<Integer> popularAgeRangePercents;
+    private List<Integer> popularGenderPercents;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseOuterDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseOuterDto.java
@@ -29,4 +29,6 @@ public class ResponseOuterDto {
     private Boolean isFavorite;
     private List<ResponseOuterSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
+    private List<Integer> popularAgeRangePercents;
+    private List<Integer> popularGenderPercents;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseTopDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseTopDto.java
@@ -29,4 +29,6 @@ public class ResponseTopDto {
     private Boolean isFavorite;
     private List<ResponseTopSizeDto> sizes;
     private List<ResponseProductDescriptionDto> descriptions;
+    private List<Integer> popularAgeRangePercents;
+    private List<Integer> popularGenderPercents;
 }

--- a/src/main/java/fittering/mall/domain/mapper/SizeMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/SizeMapper.java
@@ -45,7 +45,8 @@ public interface SizeMapper {
     })
     BottomProductDto toBottomProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<BottomDto> sizes);
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseBottomDto toResponseBottomDto(BottomProductDto bottomProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
+    ResponseBottomDto toResponseBottomDto(BottomProductDto bottomProductDto, List<ResponseProductDescriptionDto> productDescriptions,
+                                          Boolean isFavorite, List<Integer> popularAgeRangePercents, List<Integer> popularGenderPercents);
     ResponseBottomSizeDto toResponseBottomSizeDto(BottomDto bottomDto);
     Dress toDress(DressDto dressDto);
     @Mappings({
@@ -74,7 +75,8 @@ public interface SizeMapper {
     })
     DressProductDto toDressProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<DressDto> sizes);
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseDressDto toResponseDressDto(DressProductDto dressProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
+    ResponseDressDto toResponseDressDto(DressProductDto dressProductDto, List<ResponseProductDescriptionDto> productDescriptions,
+                                        Boolean isFavorite, List<Integer> popularAgeRangePercents, List<Integer> popularGenderPercents);
     ResponseDressSizeDto toResponseDressSizeDto(DressDto dressDto);
     Top toTop(TopDto topDto);
     Top toTop(CrawledSizeDto topDto);
@@ -98,7 +100,8 @@ public interface SizeMapper {
     })
     TopProductDto toTopProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<TopDto> sizes);
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseTopDto toResponseTopDto(TopProductDto topProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
+    ResponseTopDto toResponseTopDto(TopProductDto topProductDto, List<ResponseProductDescriptionDto> productDescriptions,
+                                    Boolean isFavorite, List<Integer> popularAgeRangePercents, List<Integer> popularGenderPercents);
     ResponseTopSizeDto toResponseTopSizeDto(TopDto topDto);
     Outer toOuter(OuterDto outerDto);
     Outer toOuter(CrawledSizeDto outerDto);
@@ -123,6 +126,7 @@ public interface SizeMapper {
     OuterProductDto toOuterProductDto(Long favoriteCount, Product product, String popularGender, Integer popularAgeRange, List<OuterDto> sizes);
 
     @Mapping(source = "productDescriptions", target = "descriptions")
-    ResponseOuterDto toResponseOuterDto(OuterProductDto outerProductDto, List<ResponseProductDescriptionDto> productDescriptions, Boolean isFavorite);
+    ResponseOuterDto toResponseOuterDto(OuterProductDto outerProductDto, List<ResponseProductDescriptionDto> productDescriptions,
+                                        Boolean isFavorite, List<Integer> popularAgeRangePercents, List<Integer> popularGenderPercents);
     ResponseOuterSizeDto toResponseOuterSizeDto(OuterDto outerDto);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -29,6 +29,8 @@ public interface ProductRepositoryCustom {
     Long findRecentCount(Long recentId);
     Long findRecentRecommendation(Long recentRecommendationId);
     Long findUserRecommendation(Long userRecommendationId);
+    List<Integer> findPopularAgeRangePercents(Long productId);
+    List<Integer> findPopularGenderPercents(Long productId);
     List<ResponseProductPreviewDto> timeRank(String gender);
     LocalDateTime maxUpdatedAt();
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -562,6 +562,60 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
+    public List<Integer> findPopularAgeRangePercents(Long productId) {
+        List<Long> ageRangeFavoriteCounts = queryFactory
+                .select(favorite.count())
+                .from(favorite)
+                .leftJoin(favorite.user, user)
+                .leftJoin(favorite.product, product)
+                .where(
+                        productIdEq(productId)
+                )
+                .groupBy(user.ageRange)
+                .fetch();
+
+        List<Integer> popularAgeRangePercentages = new ArrayList<>();
+
+        long totalFavoriteCount = ageRangeFavoriteCounts.stream()
+                .mapToLong(favoriteCount -> favoriteCount != null ? favoriteCount : 0L)
+                .sum();
+
+        for (Long favoriteCount : ageRangeFavoriteCounts) {
+            double percentage = (double) favoriteCount / totalFavoriteCount * 100;
+            popularAgeRangePercentages.add((int) percentage);
+        }
+
+        return popularAgeRangePercentages;
+    }
+
+    @Override
+    public List<Integer> findPopularGenderPercents(Long productId) {
+        List<Long> genderFavoriteCounts = queryFactory
+                .select(favorite.count())
+                .from(favorite)
+                .leftJoin(favorite.user, user)
+                .leftJoin(favorite.product, product)
+                .where(
+                        productIdEq(productId)
+                )
+                .groupBy(user.gender)
+                .fetch();
+
+        List<Integer> popularGenderPercentages = new ArrayList<>();
+
+        long totalFavoriteCount = genderFavoriteCounts.stream()
+                .mapToLong(favoriteCount -> favoriteCount != null ? favoriteCount : 0L)
+                .sum();
+
+        for (Long favoriteCount : genderFavoriteCounts) {
+            double percentage = (double) favoriteCount / totalFavoriteCount * 100;
+            popularGenderPercentages.add((int) percentage);
+        }
+
+        return popularGenderPercentages;
+    }
+
+    @Override
     public List<ResponseProductPreviewDto> timeRank(String gender) {
         return queryFactory
                 .select(new QResponseProductPreviewDto(

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -16,6 +16,7 @@ import fittering.mall.domain.entity.*;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 import static fittering.mall.domain.entity.QBottom.bottom;
@@ -41,6 +42,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private static final int PRICE_ASC = 2;
     private static final int MOST_POPULAR_TARGET_COUNT = 1;
     private static final int TIME_RANK_PRODUCT_COUNT = 18;
+    private static final int AGE_RANGE_SIZE = 6;
+    private static final int GENDER_SIZE = 2;
     private JPAQueryFactory queryFactory;
 
     public ProductRepositoryImpl(EntityManager em) {
@@ -563,8 +566,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     @Override
     public List<Integer> findPopularAgeRangePercents(Long productId) {
-        List<Long> ageRangeFavoriteCounts = queryFactory
-                .select(favorite.count())
+        List<Tuple> popularAgeRangeInfo = queryFactory
+                .select(user.ageRange, favorite.count())
                 .from(favorite)
                 .leftJoin(favorite.user, user)
                 .leftJoin(favorite.product, product)
@@ -574,14 +577,19 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .groupBy(user.ageRange)
                 .fetch();
 
+        int[] tempAgeRangeFavoriteCounts = new int[AGE_RANGE_SIZE];
+        int totalFavoriteCount = 0;
+        for (Tuple tuple : popularAgeRangeInfo) {
+            Integer ageRange = tuple.get(user.ageRange);
+            Integer favoriteCount = tuple.get(favorite.count()).intValue();
+            tempAgeRangeFavoriteCounts[ageRange] = favoriteCount;
+            totalFavoriteCount += favoriteCount;
+        }
+
         List<Integer> popularAgeRangePercentages = new ArrayList<>();
 
-        long totalFavoriteCount = ageRangeFavoriteCounts.stream()
-                .mapToLong(favoriteCount -> favoriteCount != null ? favoriteCount : 0L)
-                .sum();
-
-        for (Long favoriteCount : ageRangeFavoriteCounts) {
-            double percentage = (double) favoriteCount / totalFavoriteCount * 100;
+        for (int i=0; i<AGE_RANGE_SIZE; i++) {
+            double percentage = (double) tempAgeRangeFavoriteCounts[i] / totalFavoriteCount * 100;
             popularAgeRangePercentages.add((int) percentage);
         }
 
@@ -590,8 +598,8 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
 
     @Override
     public List<Integer> findPopularGenderPercents(Long productId) {
-        List<Long> genderFavoriteCounts = queryFactory
-                .select(favorite.count())
+        List<Tuple> popularGenderFavoriteInfo = queryFactory
+                .select(user.gender, favorite.count())
                 .from(favorite)
                 .leftJoin(favorite.user, user)
                 .leftJoin(favorite.product, product)
@@ -601,14 +609,19 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .groupBy(user.gender)
                 .fetch();
 
+        int[] tempGenderFavoriteCounts = new int[GENDER_SIZE];
+        int totalFavoriteCount = 0;
+        for (Tuple tuple : popularGenderFavoriteInfo) {
+            Integer genderIndex = tuple.get(user.gender).equals("M") ? 0 : 1;
+            Integer favoriteCount = tuple.get(favorite.count()).intValue();
+            tempGenderFavoriteCounts[genderIndex] = favoriteCount;
+            totalFavoriteCount += favoriteCount;
+        }
+
         List<Integer> popularGenderPercentages = new ArrayList<>();
 
-        long totalFavoriteCount = genderFavoriteCounts.stream()
-                .mapToLong(favoriteCount -> favoriteCount != null ? favoriteCount : 0L)
-                .sum();
-
-        for (Long favoriteCount : genderFavoriteCounts) {
-            double percentage = (double) favoriteCount / totalFavoriteCount * 100;
+        for (int i=0; i<GENDER_SIZE; i++) {
+            double percentage = (double) tempGenderFavoriteCounts[i] / totalFavoriteCount * 100;
             popularGenderPercentages.add((int) percentage);
         }
 

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -151,28 +151,40 @@ public class ProductService {
     public ResponseOuterDto outerProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
         Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
-        return SizeMapper.INSTANCE.toResponseOuterDto(productRepository.outerProductDetail(productId), productDescriptions, isFavorite);
+        List<Integer> popularAgeRangePercents = productRepository.findPopularAgeRangePercents(productId);
+        List<Integer> popularGenderPercents = productRepository.findPopularGenderPercents(productId);
+        return SizeMapper.INSTANCE.toResponseOuterDto(productRepository.outerProductDetail(productId), productDescriptions,
+                isFavorite, popularAgeRangePercents, popularGenderPercents);
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
     public ResponseTopDto topProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
         Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
-        return SizeMapper.INSTANCE.toResponseTopDto(productRepository.topProductDetail(productId), productDescriptions, isFavorite);
+        List<Integer> popularAgeRangePercents = productRepository.findPopularAgeRangePercents(productId);
+        List<Integer> popularGenderPercents = productRepository.findPopularGenderPercents(productId);
+        return SizeMapper.INSTANCE.toResponseTopDto(productRepository.topProductDetail(productId), productDescriptions,
+                isFavorite, popularAgeRangePercents, popularGenderPercents);
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
     public ResponseDressDto dressProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
         Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
-        return SizeMapper.INSTANCE.toResponseDressDto(productRepository.dressProductDetail(productId), productDescriptions, isFavorite);
+        List<Integer> popularAgeRangePercents = productRepository.findPopularAgeRangePercents(productId);
+        List<Integer> popularGenderPercents = productRepository.findPopularGenderPercents(productId);
+        return SizeMapper.INSTANCE.toResponseDressDto(productRepository.dressProductDetail(productId), productDescriptions,
+                isFavorite, popularAgeRangePercents, popularGenderPercents);
     }
 
     @Cacheable(value = "ProductDetail", key = "#productId")
     public ResponseBottomDto bottomProductDetail(Long userId, Long productId) {
         List<ResponseProductDescriptionDto> productDescriptions = getProductDescriptions(productId);
         Boolean isFavorite = favoriteRepository.isUserFavoriteProduct(userId, productId);
-        return SizeMapper.INSTANCE.toResponseBottomDto(productRepository.bottomProductDetail(productId), productDescriptions, isFavorite);
+        List<Integer> popularAgeRangePercents = productRepository.findPopularAgeRangePercents(productId);
+        List<Integer> popularGenderPercents = productRepository.findPopularGenderPercents(productId);
+        return SizeMapper.INSTANCE.toResponseBottomDto(productRepository.bottomProductDetail(productId), productDescriptions,
+                isFavorite, popularAgeRangePercents, popularGenderPercents);
     }
 
     public void updateView(Long productId) {


### PR DESCRIPTION
## API 수정
### 인기 정보 추가
상품 상세조회 API 응답에 **해당 상품에 대한 사용자의 선호도를 파악할 수 있도록** 연령대와 성별 정보를 제공합니다.
연령대는 `popularAgeRangePercents`, 성별은 `popularGenderPercents`에 저장하며 값의 타입은 `Integer`로 설정했습니다.
응답에서는 `List<Integer` 타입으로 제공되며 다음은 각 필드에 대한 인덱스별 값을 의미합니다.
- 연령대
  + 0 : `0-18`
  + 1 : `19-23`
  + 2 : `24-28`
  + 3 : `29-33`
  + 4 : `34-39`
  + 5 : `40-`
  + 응답 예시 : `[5, 13, 66, 7, 8, 1]`
- 성별
  + 0 : `남`
  + 1 : `여`
  + 응답 예시 : `[11, 30, 38, 17, 2, 2]`
<br>

각 필드에 담기는 값은 **선호도 비율 퍼센트**를 의미하고, 소수점을 버린 값이 들어가도록 설정했습니다.
다음은 계산했을 때 담기는 값 예시입니다.
- `94.8` -> `94`
- `35.2` -> `35`
<br>

DTO에서 수정된 내용은 다음과 같으며, `ResponseTopDto`, `ResponseDressDto`, `ResponseBottomDto` 모두 변경사항은 같습니다.
```java
public class ResponseOuterDto {
    ...
    private Boolean isFavorite;
    private List<ResponseOuterSizeDto> sizes;
    private List<ResponseProductDescriptionDto> descriptions;
    private List<Integer> popularAgeRangePercents; //추가
    private List<Integer> popularGenderPercents; //추가
}
```
- API URI : `/api/v1/auth/products/{productId}`
- [feat: 상품 상세조회 DTO 인기 연령대/성별 정보 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/f31e3c2ec51c2f0bad279a85b455ba991408f9f4)
- [feat: 상품 인기 연령대/성별 정보 얻는 쿼리 정의 및 적용](https://github.com/YeolJyeongKong/fittering-BE/commit/04fc46590cc5630f0ccff9e1bed06596dbd85423)
<br>

즐겨찾기 테이블 `Favorite`에서 `User`의 연령대 `ageRange` 또는 성별 `gender`에 대해서 **해당되는 데이터가 없을 때**
즐겨찾기 카운트를 `0`으로 제공하도록 설정했습니다. 즉, 누락된 데이터에 대해 기본값 `0`이 적용됩니다.
- 예) `ageRange`가 3인 데이터가 없을 때 : `[5, 13, 66, 0, 15, 1]`
- [fix: 연령대/성별 데이터가 존재하지 않을 시 count 0으로 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/caccd9831f210ced653de43bd9e825daaea8466e)