### PR TITLE
로직 추가 : 최근 본 상품 기반 추천에 쓰일 벡터값 업데이트

### DIFF
--- a/src/main/java/fittering/mall/domain/dto/scheduler/ProductIdsDto.java
+++ b/src/main/java/fittering/mall/domain/dto/scheduler/ProductIdsDto.java
@@ -1,0 +1,16 @@
+package fittering.mall.domain.dto.scheduler;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductIdsDto {
+    List<Long> product_ids;
+}

--- a/src/main/java/fittering/mall/scheduler/CrawlingScheduler.java
+++ b/src/main/java/fittering/mall/scheduler/CrawlingScheduler.java
@@ -2,20 +2,55 @@ package fittering.mall.scheduler;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import fittering.mall.config.kafka.KafkaProducer;
+import fittering.mall.domain.dto.scheduler.ProductIdsDto;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.JSONObject;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.util.UriComponentsBuilder;
 
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.List;
+
+@Slf4j
 @Component
 @RequiredArgsConstructor
 public class CrawlingScheduler {
 
     private final KafkaProducer kafkaProducer;
+    private final RestTemplate restTemplate;
+
+    @Value("${ML.API.PRODUCT.ENCODE}")
+    private String ML_VECTOR_UPDATE_API;
 
     private final int TWO_WEEK = 1000 * 60 * 60 * 24 * 14;
 
     @Scheduled(fixedDelay = TWO_WEEK)
     public void updateCrawledProducts() throws JsonProcessingException {
-        kafkaProducer.callCrawledProductCountAPI();
+        List<String> allProductsJson = kafkaProducer.callCrawledProductCountAPI();
+
+        URI uri = UriComponentsBuilder.fromUriString(ML_VECTOR_UPDATE_API)
+                .build()
+                .toUri();
+        List<Long> productIds = productsJsonToString(allProductsJson);
+        ProductIdsDto productIdsDto = ProductIdsDto.builder()
+                .product_ids(productIds)
+                .build();
+
+        restTemplate.postForObject(uri, productIdsDto, String.class);
+    }
+
+    public static List<Long> productsJsonToString(List<String> allProductsJson) {
+        List<Long> productIds = new ArrayList<>();
+        for (String productJson : allProductsJson) {
+            JSONObject jsonObject = new JSONObject(productJson);
+            JSONObject product = jsonObject.getJSONObject("product");
+            productIds.add((long) product.getInt("product_id"));
+        }
+        return productIds;
     }
 }


### PR DESCRIPTION
## 로직 추가
### 최근 본 상품 기반 추천에 쓰일 벡터값 업데이트
서버에서는 kafka를 통해 크롤링 DB에서 새 상품 정보를 가져와 운영 DB에 동기화 작업을 수행합니다.
그리고 핏터링에는 최근 본 상품 기반 추천 서비스가 있는데, **운영 DB에 등록된 새 상품들도 후보가 될 수 있도록** 별도로 처리해줘야 합니다.
때문에 ML 서버에서 새 상품 정보를 모델에 반영할 수 있도록 API를 제공하며, 백엔드 서버에서는 동기화 처리 후에 해당 API를 호출합니다.
다음은 API 호출 시 사용되는 요청 정보를 담은 DTO입니다.
```java
public class ProductIdsDto {
    List<Long> product_ids;
}
```
- (ML 서버) 최근 본 상품 기반 추천 모델 API : `/product_encode`
- [feat: 벡터값 업데이트 API 요청 DTO 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/5f037c95cb143ca3b3d1017d125be9810f30be29)
<br>

다음은 ML 모델 벡터값 업데이트 API를 호출하는 로직입니다.
스프링 스케쥴러에 의해 kafka에서 DB 간 동기화 작업이 끝나면 다음 로직을 수행해 **모델 벡터값에 새 상품 정보를 반영하게 됩니다.**
같은 스케쥴러 함수에서 처리되므로 **2주**마다 수행됩니다.
- [feat: 벡터값 업데이트 API 호출 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/53905182e8ddedca1d974b2e2103d2827a4beb4f)