### PR TITLE
버그 수정 : 저장된 상품없을 때 DB 동기화 불가

### DIFF
--- a/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
@@ -121,37 +121,48 @@ public class KafkaConsumer {
         JSONArray sizes = element.getJSONArray("size");
         for (int i=0; i<sizes.length(); ++i) {
             JSONObject size = sizes.getJSONObject(i);
-            double full = size.getDouble("full");
-            double shoulder = size.getDouble("shoulder");
-            double chest = size.getDouble("chest");
-            double sleeve = size.getDouble("sleeve");
-            double waist = size.getDouble("waist");
-            double thigh = size.getDouble("thigh");
-            double rise = size.getDouble("rise");
-            double bottomWidth = size.getDouble("bottom_width");
-            double hipWidth = size.getDouble("hip_width");
-            double armHall = size.getDouble("arm_hall");
-            double hip = size.getDouble("hip");
-            double sleeveWidth = size.getDouble("sleeve_width");
+            Double full = getSizeFromJson(size, "full");
+            Double shoulder = getSizeFromJson(size, "shoulder");
+            Double chest = getSizeFromJson(size, "chest");
+            Double sleeve = getSizeFromJson(size, "sleeve");
+            Double waist = getSizeFromJson(size, "waist");
+            Double thigh = getSizeFromJson(size, "thigh");
+            Double rise = getSizeFromJson(size, "rise");
+            Double bottomWidth = getSizeFromJson(size, "bottom_width");
+            Double hipWidth = getSizeFromJson(size, "hip_width");
+            Double armHall = getSizeFromJson(size, "arm_hall");
+            Double hip = getSizeFromJson(size, "hip");
+            Double sleeveWidth = getSizeFromJson(size, "sleeve_width");
 
             String name = size.getString("name");
             sizeDtos.add(CrawledSizeDto.builder()
-                    .full(full == 0.0 ? null : full)
-                    .shoulder(shoulder == 0.0 ? null : shoulder)
-                    .chest(chest == 0.0 ? null : chest)
-                    .sleeve(sleeve == 0.0 ? null : sleeve)
-                    .waist(waist == 0.0 ? null : waist)
-                    .thigh(thigh == 0.0 ? null : thigh)
-                    .rise(rise == 0.0 ? null : rise)
-                    .bottom_width(bottomWidth == 0.0 ? null : bottomWidth)
-                    .hip_width(hipWidth == 0.0 ? null : hipWidth)
-                    .arm_hall(armHall == 0.0 ? null : armHall)
-                    .hip(hip == 0.0 ? null : hip)
-                    .sleeve_width(sleeveWidth == 0.0 ? null : sleeveWidth)
+                    .full(full)
+                    .shoulder(shoulder)
+                    .chest(chest)
+                    .sleeve(sleeve)
+                    .waist(waist)
+                    .thigh(thigh)
+                    .rise(rise)
+                    .bottom_width(bottomWidth)
+                    .hip_width(hipWidth)
+                    .arm_hall(armHall)
+                    .hip(hip)
+                    .sleeve_width(sleeveWidth)
                     .name(name)
                     .build());
         }
         return sizeDtos;
+    }
+
+    private static Double getSizeFromJson(JSONObject size, String key) {
+        if (size.isNull(key)) {
+            return null;
+        }
+        if (size.has(key)) {
+            double sizeValue = size.getDouble(key);
+            return Double.isNaN(sizeValue) ? null : sizeValue;
+        }
+        return null;
     }
 
     private List<String> createImagePaths(JSONObject element) {

--- a/src/main/java/fittering/mall/config/kafka/KafkaProducer.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaProducer.java
@@ -27,6 +27,7 @@ import java.util.List;
 @Component
 public class KafkaProducer {
 
+    private final int BATCH_SIZE = 100;
     private final KafkaTemplate<String, String> kafkaTemplate;
     private final ProductService productService;
     private final RestTemplate restTemplate;
@@ -51,14 +52,14 @@ public class KafkaProducer {
 
     public List<String> produceCrawledProducts(int productsCount, LocalDateTime timeCriteria) throws JsonProcessingException {
         List<String> allProductsJson = new ArrayList<>();
-        int batchSize = productsCount % 100 == 0 ? productsCount / 100 : productsCount / 100 + 1;
-        for (int i=0; i<batchSize; ++i) {
+        int batchIndex = productsCount % BATCH_SIZE == 0 ? productsCount / BATCH_SIZE : productsCount / BATCH_SIZE + 1;
+        for (int i=0; i<batchIndex; ++i) {
             URI uri = UriComponentsBuilder.fromUriString(CRAWLED_PRODUCT_INFO_API)
                     .build()
                     .toUri();
 
-            int startId = i*100 + 1;
-            int endId = i != batchSize-1 ? (i+1) * 100 : productsCount;
+            int startId = i * BATCH_SIZE + 1;
+            int endId = i < batchIndex-1 ? (i+1) * BATCH_SIZE : productsCount;
             KafkaProductRequest request = KafkaProductRequest.builder()
                     .range(List.of(startId, endId))
                     .updated_at(timeCriteriaToString(timeCriteria))

--- a/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
@@ -29,6 +29,7 @@ public interface ProductMapper {
     @Mappings({
             @Mapping(target = "id", ignore = true),
             @Mapping(source = "crawledProductDto.name", target = "name"),
+            @Mapping(source = "image", target = "image"),
             @Mapping(source = "crawledProductDto.url", target = "origin"),
             @Mapping(source = "category", target = "category"),
             @Mapping(source = "subCategory", target = "subCategory"),

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -10,6 +10,7 @@ import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
 import java.util.List;
+import java.util.Optional;
 
 public interface ProductRepositoryCustom {
     ResponseProductPreviewDto productById(Long productId);
@@ -32,5 +33,5 @@ public interface ProductRepositoryCustom {
     List<Integer> findPopularAgeRangePercents(Long productId);
     List<Integer> findPopularGenderPercents(Long productId);
     List<ResponseProductPreviewDto> timeRank(String gender);
-    LocalDateTime maxUpdatedAt();
+    Optional<LocalDateTime> maxUpdatedAt();
 }

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -650,11 +650,12 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public LocalDateTime maxUpdatedAt() {
-        return queryFactory
+    public Optional<LocalDateTime> maxUpdatedAt() {
+        LocalDateTime maxUpdatedTime = queryFactory
                 .select(product.updatedAt.max())
                 .from(product)
                 .fetchOne();
+        return Optional.ofNullable(maxUpdatedTime);
     }
 
     public OrderSpecifier<? extends Number> filter(Long filterId) {

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -278,8 +278,8 @@ public class ProductService {
                 .orElseThrow(() -> new NoResultException("category doesn't exist"));
         SubCategory subCategory = subCategoryRepository.findById(productDto.getSub_category_id())
                 .orElseThrow(() -> new NoResultException("sub_category doesn't exist"));
-        Mall mall = mallRepository.findById(productDto.getMall_id())
-                .orElse(mallRepository.save(MallMapper.INSTANCE.toMall(mallDto)));
+        Mall mall = mallRepository.findByName(mallDto.getName())
+                .orElseGet(() -> mallRepository.save(MallMapper.INSTANCE.toMall(mallDto)));
 
         String thumbnail = CLOUDFRONT_URL + imagePaths.get(0);
         Product product = save(ProductMapper.INSTANCE.toProduct(

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -33,6 +33,8 @@ import static fittering.mall.domain.entity.Product.*;
 public class ProductService {
 
     private static final int MAX_PREVIEW_PRODUCT_COUNT = 4;
+    private static final LocalDateTime DEFAULT_TIME = LocalDateTime.of(2000, 1, 1, 0, 0, 0, 0);
+
     private final UserRepository userRepository;
     private final ProductRepository productRepository;
     private final CategoryRepository categoryRepository;
@@ -256,7 +258,7 @@ public class ProductService {
     }
 
     public LocalDateTime productsOfMaxUpdatedAt() {
-        return productRepository.maxUpdatedAt();
+        return productRepository.maxUpdatedAt().orElse(DEFAULT_TIME);
     }
 
     public void updateCrawledProducts(CrawledProductDto productDto,

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -261,6 +261,7 @@ public class ProductService {
         return productRepository.maxUpdatedAt().orElse(DEFAULT_TIME);
     }
 
+    @Transactional
     public void updateCrawledProducts(CrawledProductDto productDto,
                                       CrawledMallDto mallDto,
                                       List<CrawledSizeDto> sizeDtos,


### PR DESCRIPTION
## 버그 수정
### 저장된 상품없을 때 DB 동기화 불가
> 17:03:37.381 ERROR [scheduling-1] org.springframework.scheduling.support.TaskUtils$LoggingErrorHandler - Unexpected error occurred in scheduled task
java.lang.NullPointerException: Cannot invoke "java.time.LocalDateTime.format(java.time.format.DateTimeFormatter)" because "timeCriteria" is null

[Fittering-BE](https://github.com/YeolJyeongKong/fittering-BE)는 크롤링 DB에서 운영 DB로의 동기화 작업을 kafka로 처리하도록 구현했었습니다.
크롤링 DB에서의 상품 조회 기준을 운영 DB에 저장된 상품의 최근 업데이트 날짜로 설정했는데 **저장된 상품이 없는 경우** 예외가 발생했습니다.

즉, 저장된 상품이 없을 때 최근 업데이트 날짜 정보 `timeCriteria`가 `null`이므로 이에 대한 적절한 처리가 필요했고,
기본값 `DEFAULT_TIME`으로 대체하도록 설정했습니다. 이때는 모든 크롤링 상품을 운영 DB로 업데이트합니다.
```java
public LocalDateTime productsOfMaxUpdatedAt() {
    return productRepository.maxUpdatedAt().orElse(DEFAULT_TIME);
}
```
- [fix: 상품 최근 업데이트 기록이 없는 경우 기본값 반환](https://github.com/YeolJyeongKong/fittering-BE/commit/724d7d89ab235a279112f07e4806bd1c97448169)

### 동기화 처리 중 잘못된 쇼핑몰 조회 로직 수정
크롤링 상품 요청 스키마에 있는 `mall_id`를 기반으로 운영 DB 내 쇼핑몰 ID와 매칭되는 `Mall`을 조회하도록 설정돼 있었으나
이는 **크롤링 DB 내 `Mall`에 대한 쇼핑몰 ID이므로** 잘못된 기준으로 조회하고 있었습니다. 때문에 **이름 기반**으로 조회하도록 수정했습니다.
- [fix: 쇼핑몰 이름 기반으로 조회하도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/da4d166cadb765d5470e6eb8de3386fd4f15bef1)

### 트랜잭션 밖에서 프록시 초기화하는 문제
> Caused by: org.hibernate.LazyInitializationException: failed to lazily initialize a collection of role: fittering.mall.domain.entity.Mall.favorites: could not initialize proxy - no Session

`Product` 내에 `favorites` 필드가 `Favorite`과 연관관계를 맺고 있어서 이를 초기화해주는 로직을 MapStruct에서 생성해주고 있었으나 호출 시 트랜잭션 밖이어서 `LazyInitializationException`가 발생하는 문제가 있었습니다. **트랜잭션 내에서 처리하도록** 수정했습니다.
```java
@Transactional //추가
public void updateCrawledProducts(...) {
  Product product = save(ProductMapper.INSTANCE.toProduct(
                productDto, thumbnail, 0, 0, category, subCategory, mall));
  ...
}
```
- 📄 : [[MapStruct] LazyInitializationException: failed to lazily initialize a collection of role](https://yooniversal.github.io/project/post262/)
- [fix: 크롤링 상품 DB 반영 시 트랜잭션 내에서 처리](https://github.com/YeolJyeongKong/fittering-BE/commit/60e2f01aa761c5ccbdb2a223de331341f7f543b5)

### 크롤링 상품 정보가 null일 때 처리
> Caused by: org.springframework.orm.jpa.JpaSystemException: Unable to bind parameter #4 - NaN ['NaN' is not a valid numeric or approximate numeric value] [n/a]

크롤링 상품 데이터를 json 형태로 받는데 `Size` 정보가 `Category`에 따라 달라질 수 있기 때문에 **일부 타입 값이 `null`일 수 있습니다.**
이에 대한 처리를 해주지 않아 DB 동기화 과정이 적절히 수행되지 못했고 `JpaSystemException`가 발생했습니다.

`JSONObject.isNull()`, `JSONObject.has()`를 활용해서 특정 key에 대해 값이 `null`이면 그대로 `null`을 반환하도록 설정했습니다.
타입이 `Double`인 모든 필드에 대해 `getSizeFromJson()`를 호출해 적절한 값을 얻을 수 있도록 설정했습니다.
```java
private static Double getSizeFromJson(JSONObject size, String key) {
        if (size.isNull(key)) {
            return null;
        }
        if (size.has(key)) {
            double sizeValue = size.getDouble(key);
            return Double.isNaN(sizeValue) ? null : sizeValue;
        }
        return null;
    }
```
- [fix: 상품 json에서 값이 null일 때 처리](https://github.com/YeolJyeongKong/fittering-BE/commit/a0878e00613ecf9d70b29c7cf358664277595882)