### PR TITLE
버그 수정 : 상품 상세 이미지 불러오지 못함

### DIFF
--- a/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
+++ b/src/main/java/fittering/mall/repository/querydsl/EqualMethod.java
@@ -29,10 +29,6 @@ public class EqualMethod {
         return productId != null ? product.id.eq(productId) : null;
     }
 
-    public static BooleanExpression productDescriptionIdEq(Long productDescriptionId) {
-        return productDescriptionId != null ? productDescription.id.eq(productDescriptionId) : null;
-    }
-
     /**
      * @param mallId
      * null     : 쇼핑몰 구분X

--- a/src/main/java/fittering/mall/repository/querydsl/ProductDescriptionRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductDescriptionRepositoryImpl.java
@@ -8,7 +8,7 @@ import jakarta.persistence.EntityManager;
 import java.util.List;
 
 import static fittering.mall.domain.entity.QProductDescription.productDescription;
-import static fittering.mall.repository.querydsl.EqualMethod.productDescriptionIdEq;
+import static fittering.mall.repository.querydsl.EqualMethod.productIdEq;
 
 public class ProductDescriptionRepositoryImpl implements ProductDescriptionRepositoryCustom {
 
@@ -26,7 +26,7 @@ public class ProductDescriptionRepositoryImpl implements ProductDescriptionRepos
                 ))
                 .from(productDescription)
                 .where(
-                        productDescriptionIdEq(productId)
+                        productIdEq(productId)
                 )
                 .fetch();
     }


### PR DESCRIPTION
## 버그 수정
### 상품 상세 이미지 불러오지 못함
상품 상세조회 API에서 상품 상세 이미지/설명 전체를 불러오지 못하는 이슈가 있었습니다.
구현한 내용을 확인해보니 조건절에 `productIdEq()`가 아닌 **`productDescriptionIdEq()`를 사용하고 있어 잘못된 내용 반환하는 상태**
였고, `productDescriptionId`로 조회를 하기 때문에 1개의 상세 정보(이미지/설명)이 로드되고 있었습니다.

해당 API 호출 시 내부적으로 DB에 날리는 쿼리를 작성하는 코드는 `getProductDescrtiptions()`입니다.
where절에서 `productDescriptionId`가 아닌 `productId`를 기준으로 조회하도록 수정했습니다.
```java
@Override
public List<ProductDescriptionDto> getProductDescrtiptions(Long productId) {
    return queryFactory
            .select(new QProductDescriptionDto(
                    productDescription.url
            ))
            .from(productDescription)
            .where(
                    productIdEq(productId) //productDescriptionIdEq() -> productIdEq()
            )
            .fetch();
}
```
- [fix: 상품 상세 정보 불러오는 기준 재설정](https://github.com/YeolJyeongKong/fittering-BE/commit/e996acc0982956ef7379a9c6d5a1a7723d41cc05)