### PR TITLE
API 구현 : 쇼핑몰 이름과 ID 제공

### DIFF
--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -1,9 +1,7 @@
 package fittering.mall.controller;
 
 import fittering.mall.domain.dto.controller.request.RequestMallDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallPreviewDto;
+import fittering.mall.domain.dto.controller.response.*;
 import fittering.mall.domain.mapper.MallMapper;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.ArraySchema;
@@ -62,6 +60,14 @@ public class MallController {
         ResponseMallDto responseMallDto = mallService.findById(principalDetails.getUser().getId(), mallId);
         rankService.updateViewOnMall(principalDetails.getUser().getId(), mallId);
         return new ResponseEntity<>(responseMallDto, HttpStatus.OK);
+    }
+
+    @Operation(summary = "쇼핑몰 이름 및 ID 리스트 조회")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallNameAndIdDto.class))))
+    @GetMapping("/malls/list")
+    public ResponseEntity<?> mallList() {
+        List<ResponseMallNameAndIdDto> mallList = mallService.findMallNameAndIdList();
+        return new ResponseEntity<>(mallList, HttpStatus.OK);
     }
 
     @Operation(summary = "쇼핑몰 랭킹 조회")

--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -31,7 +31,7 @@ import static fittering.mall.controller.ControllerUtils.getValidationErrorRespon
 @Tag(name = "쇼핑몰", description = "쇼핑몰 서비스 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1")
 public class MallController {
 
     private static final int MALL_RANL_SIZE = 4;
@@ -42,7 +42,7 @@ public class MallController {
 
     @Operation(summary = "쇼핑몰 등록")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(mediaType = "application/json", schema = @Schema(type = "string"), examples = @ExampleObject(value = "\"쇼핑몰 등록 완료\"")))
-    @PostMapping("/malls")
+    @PostMapping("/auth/malls")
     public ResponseEntity<?> save(@RequestBody @Valid RequestMallDto requestMallDto,
                                   BindingResult bindingResult) {
         if (bindingResult.hasErrors()) {
@@ -54,7 +54,7 @@ public class MallController {
 
     @Operation(summary = "쇼핑몰 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMallDto.class)))
-    @GetMapping("/malls/{mallId}")
+    @GetMapping("/auth/malls/{mallId}")
     public ResponseEntity<?> mallRank(@PathVariable("mallId") @NotEmpty Long mallId,
                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
         ResponseMallDto responseMallDto = mallService.findById(principalDetails.getUser().getId(), mallId);
@@ -72,7 +72,7 @@ public class MallController {
 
     @Operation(summary = "쇼핑몰 랭킹 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallWithProductDto.class))))
-    @GetMapping("/malls/rank")
+    @GetMapping("/auth/malls/rank")
     public ResponseEntity<?> mallRank(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ResponseMallWithProductDto> malls = rankService.mallRank(principalDetails.getUser().getId());
         return new ResponseEntity<>(malls, HttpStatus.OK);
@@ -80,7 +80,7 @@ public class MallController {
 
     @Operation(summary = "쇼핑몰 랭킹 조회 (미리보기)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMallPreviewDto.class)))
-    @GetMapping("/malls/rank/preview")
+    @GetMapping("/auth/malls/rank/preview")
     public ResponseEntity<?> mallRankPreview(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                              Pageable pageable) {
         List<ResponseMallPreviewDto> malls = rankService.mallRankPreview(principalDetails.getUser().getId(),
@@ -90,7 +90,7 @@ public class MallController {
 
     @Operation(summary = "모바일 환경 쇼핑몰 랭킹 조회 (미리보기)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMallPreviewDto.class)))
-    @GetMapping("/malls/rank/preview/mobile")
+    @GetMapping("/auth/malls/rank/preview/mobile")
     public ResponseEntity<?> mallRankPreviewMobile(@AuthenticationPrincipal PrincipalDetails principalDetails,
                                                    Pageable pageable) {
         List<ResponseMallPreviewDto> malls = rankService.mallRankPreview(principalDetails.getUser().getId(),
@@ -100,7 +100,7 @@ public class MallController {
 
     @Operation(summary = "즐겨찾기 쇼핑몰 상세 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallWithProductDto.class))))
-    @GetMapping("/malls/favorite_malls")
+    @GetMapping("/auth/malls/favorite_malls")
     public ResponseEntity<?> favoriteMall(@AuthenticationPrincipal PrincipalDetails principalDetails) {
         List<ResponseMallWithProductDto> malls = favoriteService.userFavoriteMall(principalDetails.getUser().getId());
         return new ResponseEntity<>(malls, HttpStatus.OK);

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallNameAndIdDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseMallNameAndIdDto.java
@@ -1,0 +1,15 @@
+package fittering.mall.domain.dto.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseMallNameAndIdDto {
+    private Long id;
+    private String name;
+}

--- a/src/main/java/fittering/mall/domain/dto/service/MallNameAndIdDto.java
+++ b/src/main/java/fittering/mall/domain/dto/service/MallNameAndIdDto.java
@@ -1,0 +1,20 @@
+package fittering.mall.domain.dto.service;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class MallNameAndIdDto {
+    private Long id;
+    private String name;
+
+    @QueryProjection
+    public MallNameAndIdDto(Long id, String name) {
+        this.id = id;
+        this.name = name;
+    }
+}

--- a/src/main/java/fittering/mall/domain/mapper/MallMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/MallMapper.java
@@ -3,10 +3,8 @@ package fittering.mall.domain.mapper;
 import fittering.mall.config.kafka.domain.dto.CrawledMallDto;
 import fittering.mall.domain.dto.controller.request.RequestMallDto;
 import fittering.mall.domain.dto.controller.request.RequestMallRankProductDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallWithProductDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallPreviewDto;
-import fittering.mall.domain.dto.controller.response.ResponseMallRankProductDto;
+import fittering.mall.domain.dto.controller.response.*;
+import fittering.mall.domain.dto.service.MallNameAndIdDto;
 import fittering.mall.domain.dto.service.MallPreviewDto;
 import fittering.mall.domain.dto.repository.SavedMallPreviewDto;
 import fittering.mall.domain.dto.service.MallDto;
@@ -32,4 +30,5 @@ public interface MallMapper {
     ResponseMallWithProductDto toResponseMallWithProductDto(Mall mall, List<ResponseMallRankProductDto> products, Integer view, Boolean isFavorite);
     MallPreviewDto toMallPreviewDto(SavedMallPreviewDto savedMallPreviewDto);
     ResponseMallPreviewDto toResponseMallPreviewDto(MallPreviewDto mallPreviewDto, Boolean isFavorite);
+    ResponseMallNameAndIdDto toResponseMallNameAndIdDto(MallNameAndIdDto mallNameAndIdDto);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryCustom.java
@@ -1,6 +1,7 @@
 package fittering.mall.repository.querydsl;
 
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
+import fittering.mall.domain.dto.service.MallNameAndIdDto;
 
 import java.util.List;
 
@@ -8,4 +9,5 @@ public interface MallRepositoryCustom {
     List<ResponseProductPreviewDto> findProducts(String mallName);
     Long findFavoriteCount(Long mallId);
     List<String> relatedSearch(String keyword);
+    List<MallNameAndIdDto> findMallNameAndIdList();
 }

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
@@ -2,7 +2,10 @@ package fittering.mall.repository.querydsl;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 import fittering.mall.domain.dto.controller.response.QResponseProductPreviewDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallNameAndIdDto;
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
+import fittering.mall.domain.dto.service.MallNameAndIdDto;
+import fittering.mall.domain.dto.service.QMallNameAndIdDto;
 import jakarta.persistence.EntityManager;
 
 import java.util.List;
@@ -61,6 +64,17 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
                 .where(
                         mall.name.contains(keyword)
                 )
+                .fetch();
+    }
+
+    @Override
+    public List<MallNameAndIdDto> findMallNameAndIdList() {
+        return queryFactory
+                .select(new QMallNameAndIdDto(
+                        mall.id,
+                        mall.name
+                ))
+                .from(mall)
                 .fetch();
     }
 }

--- a/src/main/java/fittering/mall/service/MallService.java
+++ b/src/main/java/fittering/mall/service/MallService.java
@@ -1,7 +1,9 @@
 package fittering.mall.service;
 
 import fittering.mall.domain.dto.controller.response.ResponseMallDto;
+import fittering.mall.domain.dto.controller.response.ResponseMallNameAndIdDto;
 import fittering.mall.domain.dto.controller.response.ResponseProductPreviewDto;
+import fittering.mall.domain.dto.service.MallNameAndIdDto;
 import fittering.mall.domain.mapper.MallMapper;
 import fittering.mall.repository.FavoriteRepository;
 import jakarta.persistence.NoResultException;
@@ -14,6 +16,7 @@ import fittering.mall.domain.entity.Product;
 import fittering.mall.repository.MallRepository;
 import fittering.mall.repository.ProductRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -50,5 +53,14 @@ public class MallService {
 
     public List<ResponseProductPreviewDto> findProducts(String mallName) {
         return mallRepository.findProducts(mallName);
+    }
+
+    public List<ResponseMallNameAndIdDto> findMallNameAndIdList() {
+        List<ResponseMallNameAndIdDto> responseMallNameAndIdList = new ArrayList<>();
+        List<MallNameAndIdDto> mallNameAndIdList = mallRepository.findMallNameAndIdList();
+        mallNameAndIdList.forEach(mallNameAndId -> {
+            responseMallNameAndIdList.add(MallMapper.INSTANCE.toResponseMallNameAndIdDto(mallNameAndId));
+        });
+        return responseMallNameAndIdList;
     }
 }


### PR DESCRIPTION
## API 구현
### 쇼핑몰 이름과 ID 제공
핏터링 서비스에서 사용자가 쇼핑몰 페이지 접근 시 사용하는 URI의 `searchParams`는 **쇼핑몰 이름**을 사용합니다.
하지만 쇼핑몰 PK는 **이름이 아닌 ID이므로** 서버 DB에 저장된 모든 쇼핑몰의 이름과 ID 정보를 API 응답으로 얻은 뒤
프론트 내에서 쇼핑몰 이름을 쇼핑몰 ID로 변환해 접근하려는 쇼핑몰 페이지로 이동할 수 있도록 합니다.

다음은 응답으로 나가는 DTO `ResponseMallNameAndIdDto` 정보와 내부 구현 정보입니다.
응답으로는 `List<ResponseMallNameAndIdDto>`가 나가게 됩니다.
```java
//응답 DTO
public class ResponseMallNameAndIdDto {
    private Long id;
    private String name;
}

//API 구현 정보
@GetMapping("/malls/list")
public ResponseEntity<?> mallList() {
    List<ResponseMallNameAndIdDto> mallList = mallService.findMallNameAndIdList();
    return new ResponseEntity<>(mallList, HttpStatus.OK);
}
```

해당 API는 호출 시 권한을 필요로 하지 않도록 설정했습니다.
때문에 URI에 `/auth`가 포함되지 않습니다.
- API URI : `/malls/list`
- [feat: 쇼핑몰 이름 및 ID 리스트 API DTO 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/db0442e9184734e82531e2c7ff698e4cac72ac63)
- [feat: 쇼핑몰 이름 및 ID 리스트 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/c7686d0cfe1a8a47e3b6092f64f2b3aa5490f495)