### PR TITLE
버그 수정 : DB 동기화 시 S3 버킷 간 객체 이동이 안되는 현상

### DIFF
--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -303,13 +303,13 @@ public class ProductService {
         imagePaths.set(0, productDto.getDescription_path());
         saveProductDescriptions(imagePaths, product);
 
-        imagePaths.forEach(imagePath -> {
-            try {
-                s3Service.moveS3ObjectToServerBucket(imagePath);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-        });
+//        imagePaths.forEach(imagePath -> {
+//            try {
+//                s3Service.moveS3ObjectToServerBucket(imagePath);
+//            } catch (IOException e) {
+//                throw new RuntimeException(e);
+//            }
+//        });
 
         if (productDto.getType().equals(OUTER)) {
             getSizesOfOuter(sizeDtos, product);


### PR DESCRIPTION
## 버그 수정
### DB 동기화 시 S3 버킷 간 파일 이동이 안되는 현상
크롤링 서버에서 상품을 크롤링 DB에 등록할 때 이미지(jpg, png, ...) 및 설명(txt) 객체은 크롤링용 S3 버킷에 저장하고 있었기 때문에
kafka를 통해 크롤링 DB에서 운영 DB로 새 상품을 등록할 때 백엔드에서 사용하는 S3 버킷에 해당 객체를 가져오는 로직이 필요했습니다.
하지만 kafka에서 consumer가 해당 로직을 반드시 처리하지 않는 이슈가 있어 **운영 DB에는 객체 정보가 정상적으로 반영이 됐으나
실제로 S3 버킷 내에는 해당 객체가 없는 문제를 발견했습니다.**

정상적으로 서비스 내에 해당 객체들에 대한 렌더링을 수행하는지 확인하는 작업이 필요해 **크롤링 서버와 백엔드에서 사용하는 버킷을
일치시켜** 일시적으로 버킷 내에 파일이 없는 문제를 해결했고, 추후에 kafka에서 발생하는 이슈 해결 후 크롤링/백엔드 버킷을 분리하려고 합니다.

### 참고
kafka 이슈 수정 후엔 크롤링/백엔드 버킷을 분리할 예정이므로 버킷 간 객체를 이동하는 로직을 활성화하려고 합니다.
또한 _체형 사진을 받아 실루엣 반환하는 API #77_ 를 구현할 예정이므로 S3 접근을 위한 configuration 정보는 제거하지 않았습니다.
- [fix: S3 서버 버킷으로의 객체 전송 로직 비활성화](https://github.com/YeolJyeongKong/fittering-BE/commit/9e58456ed0ba38c1af8ab899aa5be2f0cac7397a)