### PR TITLE
API 구현 : 체형 사진을 받아 실루엣 반환

### DIFF
--- a/src/main/java/fittering/mall/config/MultipartConfig.java
+++ b/src/main/java/fittering/mall/config/MultipartConfig.java
@@ -1,0 +1,29 @@
+package fittering.mall.config;
+
+import jakarta.servlet.MultipartConfigElement;
+import org.springframework.boot.web.servlet.MultipartConfigFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.util.unit.DataSize;
+import org.springframework.web.multipart.MultipartResolver;
+import org.springframework.web.multipart.support.StandardServletMultipartResolver;
+
+@Configuration
+public class MultipartConfig {
+
+    private final static long MAX_UPLOAD_SIZE = 10485760;
+
+    @Bean
+    public MultipartResolver multipartResolver() {
+        StandardServletMultipartResolver multipartResolver = new StandardServletMultipartResolver();
+        return multipartResolver;
+    }
+
+    @Bean
+    public MultipartConfigElement multipartConfigElement() {
+        MultipartConfigFactory factory = new MultipartConfigFactory();
+        factory.setMaxRequestSize(DataSize.ofBytes(MAX_UPLOAD_SIZE));
+        factory.setMaxFileSize(DataSize.ofBytes(MAX_UPLOAD_SIZE));
+        return factory.createMultipartConfig();
+    }
+}

--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -128,9 +128,11 @@ public class UserController {
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseSilhouetteUrlDto.class)))
     @GetMapping("/users/mysize/silhouette")
     public ResponseEntity<?> silhouetteFromBody(@RequestParam("front") MultipartFile frontFile,
-                                                @RequestParam("side") MultipartFile sideFile) throws IOException {
-        String frontFileName = s3Service.saveObject(frontFile, "body");
-        String sideFileName = s3Service.saveObject(sideFile, "body");
+                                                @RequestParam("side") MultipartFile sideFile,
+                                                @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {
+        Long userId = principalDetails.getUser().getId();
+        String frontFileName = s3Service.saveObject(frontFile, userId, "body");
+        String sideFileName = s3Service.saveObject(sideFile, userId, "body");
 
         URI uri = UriComponentsBuilder.fromUriString(ML_SILHOUETTE_API)
                 .build()

--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -131,7 +131,7 @@ public class UserController {
 
     @Operation(summary = "체형 실루엣 이미지 제공")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseSilhouetteUrlDto.class)))
-    @GetMapping("/users/mysize/silhouette")
+    @PostMapping("/users/mysize/silhouette")
     public ResponseEntity<?> silhouetteFromBody(@RequestParam("bodyFile") MultipartFile bodyFile,
                                                 @RequestParam("type") String type,
                                                 @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {

--- a/src/main/java/fittering/mall/domain/dto/controller/request/RequestSilhouetteApiDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/request/RequestSilhouetteApiDto.java
@@ -10,6 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class RequestSilhouetteApiDto {
-    private String front;
-    private String side;
+    private String image_fname;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/request/RequestSilhouetteApiDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/request/RequestSilhouetteApiDto.java
@@ -1,0 +1,15 @@
+package fittering.mall.domain.dto.controller.request;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestSilhouetteApiDto {
+    private String front;
+    private String side;
+}

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteApiDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteApiDto.java
@@ -10,6 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResponseSilhouetteApiDto {
-    private String front;
-    private String side;
+    private String image_fname;
 }

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteApiDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteApiDto.java
@@ -1,0 +1,15 @@
+package fittering.mall.domain.dto.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseSilhouetteApiDto {
+    private String front;
+    private String side;
+}

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteUrlDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteUrlDto.java
@@ -1,0 +1,15 @@
+package fittering.mall.domain.dto.controller.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseSilhouetteUrlDto {
+    private String front;
+    private String side;
+}

--- a/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteUrlDto.java
+++ b/src/main/java/fittering/mall/domain/dto/controller/response/ResponseSilhouetteUrlDto.java
@@ -10,6 +10,5 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResponseSilhouetteUrlDto {
-    private String front;
-    private String side;
+    private String url;
 }

--- a/src/main/java/fittering/mall/service/S3Service.java
+++ b/src/main/java/fittering/mall/service/S3Service.java
@@ -9,11 +9,13 @@ import com.amazonaws.util.IOUtils;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URLEncoder;
+import java.time.LocalDateTime;
 
 import static java.nio.charset.StandardCharsets.*;
 
@@ -64,5 +66,30 @@ public class S3Service {
         amazonS3.putObject(serverBucket, fileName, fileInputStream, metadata);
     }
 
+    public String saveObject(MultipartFile file, String bucket) throws IOException {
+        if (bucket.equals("crawling")) {
+            return saveObjectWithBucket(file, crawlingBucket);
+        }
+        if (bucket.equals("server")) {
+            return saveObjectWithBucket(file, serverBucket);
+        }
+        if (bucket.equals("body")) {
+            return saveObjectWithBucket(file, bodyBucket);
+        }
+        if (bucket.equals("silhouette")) {
+            return saveObjectWithBucket(file, silhouetteBucket);
+        }
+        return null;
+    }
 
+    public String saveObjectWithBucket(MultipartFile file, String bucket) throws IOException {
+        String fileName = LocalDateTime.now().toString();
+        byte[] fileBytes = file.getBytes();
+        InputStream fileInputStream = new ByteArrayInputStream(fileBytes);
+        ObjectMetadata metadata = new ObjectMetadata();
+        metadata.setContentType(IMAGE_CONTENT_TYPE);
+        metadata.setContentLength(fileBytes.length);
+        amazonS3.putObject(bucket, fileName, fileInputStream, metadata);
+        return fileName;
+    }
 }

--- a/src/main/java/fittering/mall/service/S3Service.java
+++ b/src/main/java/fittering/mall/service/S3Service.java
@@ -26,13 +26,31 @@ public class S3Service {
 
     @Value("${cloud.aws.s3.bucket.crawling}")
     private String crawlingBucket;
-
     @Value("${cloud.aws.s3.bucket.server}")
     private String serverBucket;
+    @Value("${cloud.aws.s3.bucket.body}")
+    private String bodyBucket;
+    @Value("${cloud.aws.s3.bucket.silhouette}")
+    private String silhouetteBucket;
 
-    public void moveS3ObjectToServerBucket(String storedFileName) throws IOException {
-        S3Object o = amazonS3.getObject(new GetObjectRequest(crawlingBucket, storedFileName));
-        S3ObjectInputStream objectInputStream = o.getObjectContent();
+    public void moveObject(String storedFileName, String bucket) throws IOException {
+        if (bucket.equals("crawling")) {
+            moveObjectWithBucket(storedFileName, crawlingBucket);
+        }
+        if (bucket.equals("server")) {
+            moveObjectWithBucket(storedFileName, serverBucket);
+        }
+        if (bucket.equals("body")) {
+            moveObjectWithBucket(storedFileName, bodyBucket);
+        }
+        if (bucket.equals("silhouette")) {
+            moveObjectWithBucket(storedFileName, silhouetteBucket);
+        }
+    }
+
+    public void moveObjectWithBucket(String storedFileName, String bucket) throws IOException {
+        S3Object savedObject = amazonS3.getObject(new GetObjectRequest(crawlingBucket, storedFileName));
+        S3ObjectInputStream objectInputStream = savedObject.getObjectContent();
         byte[] fileBytes = IOUtils.toByteArray(objectInputStream);
         String fileName = URLEncoder.encode(storedFileName, UTF_8)
                 .replaceAll("\\+", "%20")
@@ -45,4 +63,6 @@ public class S3Service {
         metadata.setContentLength(fileBytes.length);
         amazonS3.putObject(serverBucket, fileName, fileInputStream, metadata);
     }
+
+
 }

--- a/src/main/java/fittering/mall/service/S3Service.java
+++ b/src/main/java/fittering/mall/service/S3Service.java
@@ -66,24 +66,24 @@ public class S3Service {
         amazonS3.putObject(serverBucket, fileName, fileInputStream, metadata);
     }
 
-    public String saveObject(MultipartFile file, String bucket) throws IOException {
+    public String saveObject(MultipartFile file, Long userId, String bucket) throws IOException {
         if (bucket.equals("crawling")) {
-            return saveObjectWithBucket(file, crawlingBucket);
+            return saveObjectWithBucket(file, userId, crawlingBucket);
         }
         if (bucket.equals("server")) {
-            return saveObjectWithBucket(file, serverBucket);
+            return saveObjectWithBucket(file, userId, serverBucket);
         }
         if (bucket.equals("body")) {
-            return saveObjectWithBucket(file, bodyBucket);
+            return saveObjectWithBucket(file, userId, bodyBucket);
         }
         if (bucket.equals("silhouette")) {
-            return saveObjectWithBucket(file, silhouetteBucket);
+            return saveObjectWithBucket(file, userId, silhouetteBucket);
         }
         return null;
     }
 
-    public String saveObjectWithBucket(MultipartFile file, String bucket) throws IOException {
-        String fileName = LocalDateTime.now().toString();
+    public String saveObjectWithBucket(MultipartFile file, Long userId, String bucket) throws IOException {
+        String fileName = userId + "_" + LocalDateTime.now();
         byte[] fileBytes = file.getBytes();
         InputStream fileInputStream = new ByteArrayInputStream(fileBytes);
         ObjectMetadata metadata = new ObjectMetadata();


### PR DESCRIPTION
## API 구현
### 체형 사진을 받아 실루엣 반환
핏터링 서비스는 사용자에게 정면/측면 전신 사진을 입력받으면 ML 모델에서 체형 정보를 제공하는 **체형 스마트 분석 기능**이 있습니다.
체형 스마트 분석 기능 이용 시 전신 사진을 입력받았을 때 미리보기로 입력받은 전신 사진이 아닌 **실루엣 사진을 보여줄 수 있도록** 
API를 구현했습니다.

실제로 체형 분석 시 사용자의 전신 사진으로부터 얻는 실루엣 사진만 모델에서 활용하기 때문에 **관리하는 정보는 실루엣 사진만 해당됨**을
사용자에게 알리는게 해당 기능을 이용하는데 신뢰를 줄 수 있다고 판단했습니다. 이 API는 또한 같은 목적으로써 활용됩니다.

이 API는 정면/측면 전신 사진을 **1장씩** 입력받아 처리합니다. 정면/측면임을 구분하기 위해 쿼리 스트링으로 `type`을 받도록 설정했습니다.
내부 로직에서 ML 모델을 거쳐서 실루엣 정보를 받을 수 있도록 API를 호출합니다.
```java
@PostMapping("/users/mysize/silhouette")
public ResponseEntity<?> silhouetteFromBody(@RequestParam("bodyFile") MultipartFile bodyFile,
                                            @RequestParam("type") String type,
                                            @AuthenticationPrincipal PrincipalDetails principalDetails) throws IOException {
    ...
    //실루엣 파일명을 얻기 위해 API 호출
    URI uri = UriComponentsBuilder.fromUriString(ML_SILHOUETTE_API)
            .build()
            .toUri();
    RequestSilhouetteApiDto requestSilhouetteApiDto = RequestSilhouetteApiDto.builder()
            .image_fname(savedFileName)
            .build();
    ResponseSilhouetteApiDto responseSilhouetteApiDto = restTemplate.postForObject(uri, requestSilhouetteApiDto, ResponseSilhouetteApiDto.class);

    //웹 배포된 URI로 응답 제공
    ResponseSilhouetteUrlDto responseSilhouetteUrlDto = ResponseSilhouetteUrlDto.builder()
            .url(CLOUDFRONT_SILHOUETTE_URL + responseSilhouetteApiDto.getImage_fname())
            .build();
    return new ResponseEntity<>(responseSilhouetteUrlDto, HttpStatus.OK);
}
```
<br>

- [feat: ML 서버 실루엣 반환 API의 요청 및 응답 DTO 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/305e6ef9d3e055fee8a06739244ea3e17eca5d52)
- [feat: 실루엣 URI 반환 API 응답 DTO 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/a57eee30b3d4e55ac5267700c734d1798f7ac024)
- [feat: 체형 실루엣 이미지 제공 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/bda81a56497e6e15cbdbca5b42e19c7c1ccc3389)
- [fix: 전신 사진을 한 장씩 받아 처리하도록 실루엣 API 구현 내용 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/8a0b8ea8c8c311294c6ac0eeab02eb301b4b828c)
<br>

### 실루엣 파일명 정보 유지
실루엣 파일명은 `userId`와 현재 시간 `timestamp` 형식의 데이터를 조합한 값으로 설정했기 때문에, 이 API 호출 이후 스마트 분석 버튼을
눌렀을 때 입력으로 필요한 정면/측면 실루엣 파일명을 가져올 수 없습니다. 그래서 해당 정보를 유지하기 위해 **Redis 캐시**를 활용했습니다.
실루엣 파일은 스마트 분석 API 호출 후에는 캐시에 유지할 필요가 없으므로 제거할 예정입니다.

정면/측면 여부 정보는 `isFront`로 받으며, 캐시에서 key는 `userId`와 `KEY_SUFFIX`의 조합으로, value는 `savedFileName`으로 설정했습니다.
```java
private void saveSilhouetteFileNameInCache(Long userId, boolean isFront, String savedFileName) {
    if (isFront) {
        redisTemplate.opsForValue().set(userId + FRONT_SILHOUETTE_KEY_SUFFIX, savedFileName);
        return;
    }
    redisTemplate.opsForValue().set(userId + SIDE_SILHOUETTE_KEY_SUFFIX, savedFileName);
}

private void deleteSilhouetteFileNameInCache(Long userId, boolean isFront) {
    if (isFront) {
        redisTemplate.delete(userId + FRONT_SILHOUETTE_KEY_SUFFIX);
        return;
    }
    redisTemplate.delete(userId + SIDE_SILHOUETTE_KEY_SUFFIX);
}
```
- key 정보
  + 정면 : `userId + FRONT_SILHOUETTE_KEY_SUFFIX`
  + 측면 : `userId + SIDE_SILHOUETTE_KEY_SUFFIX`
- Redis 캐시
  + 등록 : `saveSilhouetteFileNameInCache(Long userId, boolean isFront, String savedFileName)`
  + 삭제 : `deleteSilhouetteFileNameInCache(Long userId, boolean isFront)`

### MultipartFile 설정
파일 업로드 기능을 지원하기 위해 `MultipartFile` 설정 클래스 `MultipartConfig`를 정의했습니다.
HTTP 요청에서 multipart 처리를 통해 파일 업로드 기능을 지원하도록 `MultipartResolver`를 스프링 빈으로 등록하고,
파일 처리 용량 상한을 설정해주기 위해 `MultipartConfigElement`를 스프링 빈으로 등록합니다.
- [feat: 파일 업로드 설정 클래스 등록](https://github.com/YeolJyeongKong/fittering-BE/commit/e7d3d0fad97ed5485e07e126f725c9f34a7f115d)
- 트러블 슈팅
  + [[Spring] multipart.MultipartException: Current request is not a multipart request](https://yooniversal.github.io/project/post263/)
