### PR TITLE
버그 수정 : API URI 구조가 같아 동작하지 않음

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -138,7 +138,7 @@ public class ProductController {
 
     @Operation(summary = "쇼핑몰 카테고리별 상품 조회 (소분류)")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductPreviewDto.class))))
-    @GetMapping("/malls/{mallId}/{subCategoryId}/{gender}/{filterId}")
+    @GetMapping("/malls/sub/{mallId}/{subCategoryId}/{gender}/{filterId}")
     public ResponseEntity<?> productWithSubCategoryOfMall(@PathVariable("mallId") @NotEmpty Long mallId,
                                                           @PathVariable("subCategoryId") @NotEmpty Long subCategoryId,
                                                           @PathVariable("gender") @NotEmpty String gender,


### PR DESCRIPTION
## 버그 수정
### API URI 구조가 같아 동작하지 않음
> java.lang.IllegalStateException: **Ambiguous handler methods** mapped for '/api/v1/malls/7/0/A/0'

쇼핑몰 카테고리별 대소분류 기준 상품 조회 API **모두 URI 구조가 같아** 어떤 API를 호출하든지 모두 위 에러가 발생했습니다.
때문에 소분류 기준 상품 조회 API에서는 `malls/...`에서 **`/malls/sub/...`로 수정**해 대소분류 API URI를 모두 구분했습니다.

다음은 수정한 코드입니다.
```java
//쇼핑몰 카테고리별 상품 조회 API (소분류)
@GetMapping("/malls/sub/{mallId}/{subCategoryId}/{gender}/{filterId}")
public ResponseEntity<?> productWithSubCategoryOfMall(@PathVariable("mallId") @NotEmpty Long mallId,
                                                      @PathVariable("subCategoryId") @NotEmpty Long subCategoryId,
                                                      @PathVariable("gender") @NotEmpty String gender,
                                                      @PathVariable("filterId") @NotEmpty Long filterId,
                                                      Pageable pageable) {
  …
}
```
<br>

- 📄: [[Spring] IllegalStateException: Ambiguous handler methods](https://yooniversal.github.io/project/post264/)
- [fix: 쇼핑몰 카테고리별 상품 조회 대소분류 API 구조 다르도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/5da90d42813d05c837b91fc449e5943458a7c8d8)