### PR TITLE
API 수정 : 회원 탈퇴 input 필드 추가

### DIFF
--- a/src/main/java/fittering/mall/controller/dto/request/RequestUserCheckDto.java
+++ b/src/main/java/fittering/mall/controller/dto/request/RequestUserCheckDto.java
@@ -1,0 +1,14 @@
+package fittering.mall.controller.dto.request;
+
+import lombok.*;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RequestUserCheckDto {
+    @NonNull
+    private String email;
+    @NonNull
+    private String password;
+}

--- a/src/main/java/fittering/mall/service/UserService.java
+++ b/src/main/java/fittering/mall/service/UserService.java
@@ -229,6 +229,19 @@ public class UserService {
         });
     }
 
+    public boolean isValidEmailAndPassword(String email, String password) {
+        User user = findByEmail(email);
+        if (user == null) {
+            return false;
+        }
+        return passwordEncoder.matches(password, user.getPassword());
+    }
+
+    public boolean isSameUser(Long userId, String email) {
+        User user = findById(userId);
+        return user.getEmail().equals(email);
+    }
+
     private void updateRecentLastInitializedAtOfUser(User user) {
         if (user.getRecentLastInitializedAt() == null) {
             user.updateRecentLastInitializedAt();


### PR DESCRIPTION
## API 수정
### 회원 탈퇴 input 필드 추가
회원 탈퇴 버튼을 누를 때 **이메일과 비밀번호를 입력 받도록 해** 한차례 검증 과정이 있도록 설정했습니다.
이메일과 비밀번호를 기반으로 유효한 유저 정보를 DB에서 찾지 못했거나, 현재 접속한 유저의 정보와 다를 경우 회원 탈퇴 처리를 하지 않습니다.

검증 성공 여부는 **HTTP 상태 코드로 구분**합니다.
- 성공 : `200` -> **회원 탈퇴**
- 실패 : `400`

```java
@DeleteMapping("/users")
public ResponseEntity<?> deleteUser(@RequestBody RequestUserCheckDto requestUserCheckDto,
                                    @AuthenticationPrincipal PrincipalDetails principalDetails) {
    //입력 email/password 검증 및 현재 사용자와 같은지 확인
    String email = requestUserCheckDto.getEmail();
    String password = requestUserCheckDto.getPassword();
    Long currentUserid = principalDetails.getUser().getId();
    if (userService.isValidEmailAndPassword(email, password) && userService.isSameUser(currentUserid, email)) {
        userService.delete(principalDetails.getUser().getId());
        return new ResponseEntity<>("회원 탈퇴 완료", HttpStatus.OK); //성공
    }
    return new ResponseEntity<>("회원 탈퇴 실패", HttpStatus.BAD_REQUEST); //실패
}
```
<br>

- [fix: 회원탈퇴 API에 이메일 및 비밀번호 검증 로직 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/1c6298db04022d6cfb8e6964669cb88b13c978f5)