### PR TITLE
테이블 수정 : Measurement 필드 타입 Double로 설정

### DIFF
--- a/src/main/java/fittering/mall/controller/dto/request/RequestMeasurementDto.java
+++ b/src/main/java/fittering/mall/controller/dto/request/RequestMeasurementDto.java
@@ -8,14 +8,14 @@ import lombok.*;
 @AllArgsConstructor
 public class RequestMeasurementDto {
     @NonNull
-    private Integer height;
+    private Double height;
     @NonNull
-    private Integer weight;
-    private Integer arm;
-    private Integer leg;
-    private Integer shoulder;
-    private Integer waist;
-    private Integer chest;
-    private Integer thigh;
-    private Integer hip;
+    private Double weight;
+    private Double arm;
+    private Double leg;
+    private Double shoulder;
+    private Double waist;
+    private Double chest;
+    private Double thigh;
+    private Double hip;
 }

--- a/src/main/java/fittering/mall/domain/entity/Measurement.java
+++ b/src/main/java/fittering/mall/domain/entity/Measurement.java
@@ -19,15 +19,15 @@ public class Measurement extends BaseEntity {
     @Column(name = "measurement_id")
     private Long id;
 
-    private Integer height;
-    private Integer weight;
-    private Integer arm;
-    private Integer leg;
-    private Integer shoulder;
-    private Integer waist;
-    private Integer chest;
-    private Integer thigh;
-    private Integer hip;
+    private Double height;
+    private Double weight;
+    private Double arm;
+    private Double leg;
+    private Double shoulder;
+    private Double waist;
+    private Double chest;
+    private Double thigh;
+    private Double hip;
 
     @JsonIgnore
     @OneToOne(mappedBy = "measurement", fetch = LAZY)

--- a/src/main/java/fittering/mall/repository/dto/SavedMeasurementDto.java
+++ b/src/main/java/fittering/mall/repository/dto/SavedMeasurementDto.java
@@ -9,19 +9,19 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 public class SavedMeasurementDto {
-    private Integer height;
-    private Integer weight;
-    private Integer arm;
-    private Integer leg;
-    private Integer shoulder;
-    private Integer waist;
-    private Integer chest;
-    private Integer thigh;
-    private Integer hip;
+    private Double height;
+    private Double weight;
+    private Double arm;
+    private Double leg;
+    private Double shoulder;
+    private Double waist;
+    private Double chest;
+    private Double thigh;
+    private Double hip;
 
     @QueryProjection
-    public SavedMeasurementDto(Integer height, Integer weight, Integer arm, Integer leg, Integer shoulder,
-                               Integer waist, Integer chest, Integer thigh, Integer hip) {
+    public SavedMeasurementDto(Double height, Double weight, Double arm, Double leg, Double shoulder,
+                               Double waist, Double chest, Double thigh, Double hip) {
         this.height = height;
         this.weight = weight;
         this.arm = arm;

--- a/src/main/java/fittering/mall/service/dto/MeasurementDto.java
+++ b/src/main/java/fittering/mall/service/dto/MeasurementDto.java
@@ -10,13 +10,13 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class MeasurementDto {
-    private Integer height;
-    private Integer weight;
-    private Integer arm;
-    private Integer leg;
-    private Integer shoulder;
-    private Integer waist;
-    private Integer chest;
-    private Integer thigh;
-    private Integer hip;
+    private Double height;
+    private Double weight;
+    private Double arm;
+    private Double leg;
+    private Double shoulder;
+    private Double waist;
+    private Double chest;
+    private Double thigh;
+    private Double hip;
 }

--- a/src/test/java/fittering/mall/service/UserServiceTest.java
+++ b/src/test/java/fittering/mall/service/UserServiceTest.java
@@ -145,7 +145,17 @@ class UserServiceTest {
         ResponseMeasurementDto measurement = userService.measurementInfo(user.getId());
         measurementCheck(measurement, new ResponseMeasurementDto());
 
-        MeasurementDto newMeasurment = new MeasurementDto(200, 100, 100, 120, 100, 99, 98, 80, 76);
+        MeasurementDto newMeasurment = MeasurementDto.builder()
+                        .height(200.0)
+                        .weight(100.0)
+                        .arm(100.0)
+                        .leg(120.0)
+                        .shoulder(100.0)
+                        .waist(99.0)
+                        .chest(98.0)
+                        .thigh(80.0)
+                        .hip(76.0)
+                        .build();
         userService.measurementUpdate(newMeasurment, user.getId());
 
         measurementCheck(MeasurementMapper.INSTANCE.toResponseMeasurementDto(newMeasurment),


### PR DESCRIPTION
## 테이블 수정
### Measurement 필드 수정
**모델 학습 시 정확도 측면**에서 학습시킬 값을 `Integer`보다 `Double`로 입력하는게 좋기 때문에
`Measurement` 엔티티에서 모든 체형 필드를 `Integer`에서 `Double`로 수정했습니다.
엔티티 외에도 `Measurment`와 관련된 DTO 내 체형 필드들도 `Double` 타입으로 수정했습니다.

다음은 수정한 `Measurement` 엔티티 정보입니다.
```java
public class Measurement {
    //체형 타입 : Integer -> Double
    private Double height;
    private Double weight;
    private Double arm;
    private Double leg;
    private Double shoulder;
    private Double waist;
    private Double chest;
    private Double thigh;
    private Double hip;
    ...
}
```
- [feat: Measurement 엔티티 필드 Double로 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/628dd768c106b1cd5d45df84d44a906e224a5bd9)
- [feat: Measurement DTO 필드 Double로 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/b46c4bd74c702f44250d661f5d026eb54065a836)