### PR TITLE
버그 수정 : 카테고리 간 상품 조회 시 구분이 안되는 현상

### DIFF
--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -66,7 +66,7 @@ public class ProductService {
                 .orElseThrow(() -> new NoResultException("product dosen't exist"));
     }
 
-    @Cacheable(value = "Product", key = "'0_' + #categoryId + '_' + #gender + '_' + #filterId + '_' + #pageable.pageNumber")
+    @Cacheable(value = "Product", key = "'0_' + #productParamDto.categoryId + '_' + #productParamDto.gender + '_' + #productParamDto.filterId + '_' + #pageable.pageNumber")
     public RestPage<ResponseProductPreviewDto> productWithCategory(ProductParamDto productParamDto, Pageable pageable) {
         Long categoryId = productParamDto.getCategoryId();
         String gender = productParamDto.getGender();
@@ -74,7 +74,7 @@ public class ProductService {
         return new RestPage<>(productRepository.productWithCategory(null, categoryId, gender, filterId, pageable));
     }
 
-    @Cacheable(value = "Product", key = "'1_' + #subCategoryId + '_' + #gender + '_' + #filterId + '_' + #pageable.pageNumber")
+    @Cacheable(value = "Product", key = "'1_' + #productParamDto.subCategoryId + '_' + #productParamDto.gender + '_' + #productParamDto.filterId + '_' + #pageable.pageNumber")
     public RestPage<ResponseProductPreviewDto> productWithSubCategory(ProductParamDto productParamDto, Pageable pageable) {
         Long subCategoryId = productParamDto.getSubCategoryId();
         String gender = productParamDto.getGender();
@@ -82,7 +82,7 @@ public class ProductService {
         return new RestPage<>(productRepository.productWithSubCategory(null, subCategoryId, gender, filterId, pageable));
     }
 
-    @Cacheable(value = "MallProduct", key = "#mallId + '_' + #categoryId + '_' + #gender + '_' + #filterId +  '_' + #pageable.pageNumber")
+    @Cacheable(value = "MallProduct", key = "#productParamDto.mallId + '_' + #productParamDto.categoryId + '_' + #productParamDto.gender + '_' + #productParamDto.filterId +  '_' + #pageable.pageNumber")
     public RestPage<ResponseProductPreviewDto> productWithCategoryOfMall(ProductParamDto productParamDto, Pageable pageable) {
         Long mallId = productParamDto.getMallId();
         Long categoryId = productParamDto.getCategoryId();
@@ -91,7 +91,7 @@ public class ProductService {
         return new RestPage<>(productRepository.productWithCategory(mallId, categoryId, gender, filterId, pageable));
     }
 
-    @Cacheable(value = "MallProduct", key = "'sub_' + #mallId + '_' + #subCategoryId + '_' + #gender + '_' + #filterId +  '_' + #pageable.pageNumber")
+    @Cacheable(value = "MallProduct", key = "'sub_' + #productParamDto.mallId + '_' + #productParamDto.subCategoryId + '_' + #productParamDto.gender + '_' + #productParamDto.filterId +  '_' + #pageable.pageNumber")
     public RestPage<ResponseProductPreviewDto> productWithSubCategoryOfMall(ProductParamDto productParamDto, Pageable pageable) {
         Long mallId = productParamDto.getMallId();
         Long subCategoryId = productParamDto.getSubCategoryId();


### PR DESCRIPTION
## 버그 수정
### 카테고리 간 상품 조회 시 구분이 안되는 현상
핏터링 서비스 내 구현된 상품 조회 관련 API는 총 4개가 있습니다.
- 카테고리별 상품 조회 (대분류)
- 카테고리별 상품 조회 (소분류)
- 쇼핑몰 카테고리별 상품 조회 (대분류)
- 쇼핑몰 카테고리별 상품 조회 (소분류)

각 API 내에서 대분류는 아우터, 상의 등, 소분류는 후드 집업, 코트 등을 기준으로 구분합니다.
이때 **어떤 기준으로 조회하던지 상관없이** 같은 상품을 불러오는 오류가 있었습니다.
확인해보니 **Redis 캐시 내 key 값에 `null`이 포함돼** 잘못 불러온 상품을 캐싱해서 계속 응답으로 주는 문제가 있었습니다.
```
# redis-cli
127.0.0.1:6379> keys *
1) "MallProduct::sub_null_null_null_null_0"
```

#111 에서 위 API에 대해 공통 파라미터들을 DTO `ProductParamDto`로 묶으면서 캐시 key를 적절하게 설정해주지 않아 `null`로 저장됐음을 확인했습니다. 예시로 기존에 key에 들어가는 값은 `categoryId`로 파라미터에도 있었으나, `ProductParamDto`로 교체하면서 **인식할 수 없는 문제가 있었습니다.** 

다음은 수정한 메소드 중 일부입니다.
```java
// @Cacheable(value = "Product", key = "'0_' + #categoryId + '_' + #gender + '_' + #filterId + '_' + #pageable.pageNumber")
@Cacheable(value = "Product", key = "'0_' + #productParamDto.categoryId + '_' + #productParamDto.gender + '_' + #productParamDto.filterId + '_' + #pageable.pageNumber")
public RestPage<ResponseProductPreviewDto> productWithCategory(ProductParamDto productParamDto, Pageable pageable) {
    Long categoryId = productParamDto.getCategoryId();
    String gender = productParamDto.getGender();
    Long filterId = productParamDto.getFilterId();
    return new RestPage<>(productRepository.productWithCategory(null, categoryId, gender, filterId, pageable));
}
```
- [fix: 상품 조회 서비스 메소드 캐시 key 값 재설정](https://github.com/YeolJyeongKong/fittering-BE/commit/95f0a08548b1cfc7e3315447a1813159aa6b74f8)