### PR TITLE
버그 수정 : DB 간 동기화 시 모든 상품 데이터를 반영하지 못하는 문제

### DIFF
--- a/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
@@ -10,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.springframework.kafka.annotation.KafkaListener;
+import org.springframework.kafka.support.Acknowledgment;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -23,28 +24,33 @@ public class KafkaConsumer {
     private final ProductService productService;
 
     @KafkaListener(topics = "crawling-topic-0", groupId = "crawl-group-id")
-    public void consumeCrawledProductsV0(String productJson) {
+    public void consumeCrawledProductsV0(String productJson, Acknowledgment acknowledgment) {
         updateCrawledProductsProduct(productJson);
+        acknowledgment.acknowledge();
     }
 
     @KafkaListener(topics = "crawling-topic-1", groupId = "crawl-group-id")
-    public void consumeCrawledProductsV1(String productJson) {
+    public void consumeCrawledProductsV1(String productJson, Acknowledgment acknowledgment) {
         updateCrawledProductsProduct(productJson);
+        acknowledgment.acknowledge();
     }
 
     @KafkaListener(topics = "crawling-topic-2", groupId = "crawl-group-id")
-    public void consumeCrawledProductsV2(String productJson) {
+    public void consumeCrawledProductsV2(String productJson, Acknowledgment acknowledgment) {
         updateCrawledProductsProduct(productJson);
+        acknowledgment.acknowledge();
     }
 
     @KafkaListener(topics = "crawling-topic-3", groupId = "crawl-group-id")
-    public void consumeCrawledProductsV3(String productJson) {
+    public void consumeCrawledProductsV3(String productJson, Acknowledgment acknowledgment) {
         updateCrawledProductsProduct(productJson);
+        acknowledgment.acknowledge();
     }
 
     @KafkaListener(topics = "crawling-topic-4", groupId = "crawl-group-id")
-    public void consumeCrawledProductsV4(String productJson) {
+    public void consumeCrawledProductsV4(String productJson, Acknowledgment acknowledgment) {
         updateCrawledProductsProduct(productJson);
+        acknowledgment.acknowledge();
     }
 
     private void updateCrawledProductsProduct(String productJson) {

--- a/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaConsumer.java
@@ -25,30 +25,30 @@ public class KafkaConsumer {
 
     @KafkaListener(topics = "crawling-topic-0", groupId = "crawl-group-id")
     public void consumeCrawledProductsV0(String productJson, Acknowledgment acknowledgment) {
-        updateCrawledProductsProduct(productJson);
-        acknowledgment.acknowledge();
+        processConsumedProduct(productJson, acknowledgment);
     }
 
     @KafkaListener(topics = "crawling-topic-1", groupId = "crawl-group-id")
     public void consumeCrawledProductsV1(String productJson, Acknowledgment acknowledgment) {
-        updateCrawledProductsProduct(productJson);
-        acknowledgment.acknowledge();
+        processConsumedProduct(productJson, acknowledgment);
     }
 
     @KafkaListener(topics = "crawling-topic-2", groupId = "crawl-group-id")
     public void consumeCrawledProductsV2(String productJson, Acknowledgment acknowledgment) {
-        updateCrawledProductsProduct(productJson);
-        acknowledgment.acknowledge();
+        processConsumedProduct(productJson, acknowledgment);
     }
 
     @KafkaListener(topics = "crawling-topic-3", groupId = "crawl-group-id")
     public void consumeCrawledProductsV3(String productJson, Acknowledgment acknowledgment) {
-        updateCrawledProductsProduct(productJson);
-        acknowledgment.acknowledge();
+        processConsumedProduct(productJson, acknowledgment);
     }
 
     @KafkaListener(topics = "crawling-topic-4", groupId = "crawl-group-id")
     public void consumeCrawledProductsV4(String productJson, Acknowledgment acknowledgment) {
+        processConsumedProduct(productJson, acknowledgment);
+    }
+
+    private void processConsumedProduct(String productJson, Acknowledgment acknowledgment) {
         updateCrawledProductsProduct(productJson);
         acknowledgment.acknowledge();
     }

--- a/src/main/java/fittering/mall/config/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaConsumerConfig.java
@@ -1,0 +1,50 @@
+package fittering.mall.config.kafka;
+
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.apache.kafka.common.serialization.StringDeserializer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.annotation.EnableKafka;
+import org.springframework.kafka.config.ConcurrentKafkaListenerContainerFactory;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.DefaultKafkaConsumerFactory;
+import org.springframework.kafka.listener.ContainerProperties;
+import org.springframework.kafka.support.serializer.JsonDeserializer;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+@EnableKafka
+public class KafkaConsumerConfig {
+
+    @ConditionalOnMissingBean
+    public ConsumerFactory<String, String> consumerFactory() {
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,"127.0.0.1:9092");
+        props.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, StringDeserializer.class);
+        props.put(JsonDeserializer.TRUSTED_PACKAGES, "*");
+        props.put(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "latest");
+        props.put(ConsumerConfig.GROUP_ID_CONFIG, "crawl-group-id");
+
+        props.put(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false);
+        props.put(ConsumerConfig.MAX_POLL_RECORDS_CONFIG, 20);
+        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 15000);
+        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 1000);
+        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 60000);
+
+        return new DefaultKafkaConsumerFactory<>(props);
+
+    }
+
+    @Bean(name="kafkaListenerContainerFactory")
+    public ConcurrentKafkaListenerContainerFactory<String, String> kafkaListenerContainerFactory() {
+        ConcurrentKafkaListenerContainerFactory<String, String> factory = new ConcurrentKafkaListenerContainerFactory<>();
+        factory.setConsumerFactory(consumerFactory());
+        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
+        return factory;
+    }
+}

--- a/src/main/java/fittering/mall/config/kafka/KafkaTemplateConfig.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaTemplateConfig.java
@@ -14,11 +14,13 @@ import java.util.Map;
 @Configuration
 public class KafkaTemplateConfig {
 
+    private static final String BOOTSTRAP_SERVER = "localhost:9092";
+
     @Bean
     public KafkaTemplate<String, String> customKafkaTemplate() {
 
         Map<String, Object> props = new HashMap<>();
-        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVER);
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         props.put(ProducerConfig.ACKS_CONFIG, "all");

--- a/src/main/java/fittering/mall/config/kafka/KafkaTemplateConfig.java
+++ b/src/main/java/fittering/mall/config/kafka/KafkaTemplateConfig.java
@@ -1,0 +1,31 @@
+package fittering.mall.config.kafka;
+
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaTemplateConfig {
+
+    @Bean
+    public KafkaTemplate<String, String> customKafkaTemplate() {
+
+        Map<String, Object> props = new HashMap<>();
+        props.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG, "localhost:9092");
+        props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        props.put(ProducerConfig.ACKS_CONFIG, "all");
+        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "3000");
+
+        // ProducerFactory를 사용하여 KafkaTemplate 객체를 만들 때는 프로듀서 옵션을 직접 넣음
+        ProducerFactory<String, String> producerFactory = new DefaultKafkaProducerFactory<>(props);
+        return new KafkaTemplate<>(producerFactory);
+    }
+}

--- a/src/main/java/fittering/mall/repository/ProductRepository.java
+++ b/src/main/java/fittering/mall/repository/ProductRepository.java
@@ -1,9 +1,11 @@
 package fittering.mall.repository;
 
+import jakarta.persistence.LockModeType;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 import fittering.mall.domain.entity.Product;
 import fittering.mall.repository.querydsl.ProductRepositoryCustom;
+import org.springframework.data.jpa.repository.Lock;
 
 import java.util.Optional;
 
@@ -11,5 +13,7 @@ public interface ProductRepository extends JpaRepository<Product, Long>, Product
     @Override
     @EntityGraph(attributePaths = {"mall", "category"})
     Optional<Product> findById(Long productId);
+
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
     Optional<Product> findByName(String name);
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -386,4 +386,13 @@ public class ProductService {
                     .build());
         });
     }
+
+    public Optional<Long> getNewProductId(String productName) {
+        Optional<Product> optionalProduct = productRepository.findByName(productName);
+        if (optionalProduct.isPresent()) {
+            Product product = optionalProduct.get();
+            return Optional.of(product.getId());
+        }
+        return Optional.empty();
+    }
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -387,6 +387,7 @@ public class ProductService {
         });
     }
 
+    @Transactional
     public Optional<Long> getNewProductId(String productName) {
         Optional<Product> optionalProduct = productRepository.findByName(productName);
         if (optionalProduct.isPresent()) {


### PR DESCRIPTION
# 버그 수정
핏터링 서비스 아키텍처에서는 서비스에서 활용되는 데이터를 담은 운영 DB와 크롤링 상품 데이터를 담은 크롤링 DB를 운영하고 있습니다.
일정 주기마다 크롤링 DB에 있는 상품들을 운영 DB로 업데이트하고 있습니다. 여기에서는 업데이트 과정 중 발생한 문제에 대해서 다룹니다.

## DB 간 동기화 시 모든 상품 데이터를 반영하지 못하는 문제
kafka로 DB 간 동기화하는 작업 중 Producer에서 브로커에 데이터를 넣는 과정은 정상적으로 이루어지고 있으나, **Consumer에 문제가 있는 것으로** 판단했습니다. 즉, 크롤링 DB에서 모든 상품 정보를 가져오는덴 문제가 없으나 Consumer에서 모든 상품을 작업하지 않는 문제가 발생했습니다.

### Consumer 설정 클래스 정의
기존에는 Consumer 설정을 `application.yml`에 했으나 **세부 설정을 위해** 설정 클래스 `KafkaConsumerConfig`를 정의했습니다.
```java
@Configuration
@EnableKafka
public class KafkaConsumerConfig {

    @ConditionalOnMissingBean
    public ConsumerFactory<String, String> consumerFactory() {
        ...
        props.put(ConsumerConfig.MAX_POLL_INTERVAL_MS_CONFIG, 15000);
        props.put(ConsumerConfig.HEARTBEAT_INTERVAL_MS_CONFIG, 1000);
        props.put(ConsumerConfig.SESSION_TIMEOUT_MS_CONFIG, 60000);
        return new DefaultKafkaConsumerFactory<>(props);
    }

    @Bean(name="kafkaListenerContainerFactory")
        ...
        factory.getContainerProperties().setAckMode(ContainerProperties.AckMode.MANUAL_IMMEDIATE);
        return factory;
    }
}
```
- `MAX_POLL_INTERVAL_MS_CONFIG` : Consumer 메시지 처리 주기
- `HEARTBEAT_INTERVAL_MS_CONFIG` : Consumer가 살아있는지 알리는 신호를 브로커에 보내는 주기
- `SESSION_TIMEOUT_MS_CONFIG` : Consumer 그룹의 멤버가 브로커와 연결을 유지해야 하는 시간
- `AckMode` → `MANUAL_IMMEDIATE` : Acknowledging이 붙은 리스너 사용
- [feat: kafka consumer configuration 등록](https://github.com/YeolJyeongKong/fittering-BE/commit/9a2956d16aa283b3c5ed79e0bc04e60e3fbfca5c)

### Consumer에 Acknowledgment 설정
메시지 처리 후 `acknowledgment.acknowledge()`를 호출해 해당 메시지의 offset을 커밋합니다.
Consumer는 커밋된 offset 이후의 메시지부터 처리하게 되므로 **중복 처리를 방지하고 메시지 처리의 신뢰성을 유지**할 수 있습니다.
```java
@KafkaListener(topics = "crawling-topic", groupId = "crawl-group-id")
public void consumeCrawledProductsV4(String productJson, Acknowledgment acknowledgment) {
    updateCrawledProductsProduct(productJson);
    acknowledgment.acknowledge(); //메시지 offset 커밋
    ...
}
```
- [feat: Acknowledgment 사용해 메시지 offset 관리](https://github.com/YeolJyeongKong/fittering-BE/commit/976ce0ac988cbb889a96225f697a1078f5ec2d9b)

### 상품 조회 Lock 설정
> Caused by: org.springframework.dao.IncorrectResultSizeDataAccessException: query did not return a unique result: 6

Consumer 내 여러 스레드가 상품 조회 메소드 `findByName()`에 동시에 접근하면 이후 로직에 있는 상품 저장 메소드 `save()`를 호출하면서 같은 이름의 **상품을 여러번 등록하게 됩니다.**

이후 동기화 작업 시 `findByName()`을 호출했을 때 **IncorrectResultSizeDataAccessException**를 발생해 작업이 정상적으로 처리되지 않는 문제가 있었습니다. 때문에 **싱글 스레드만 동기화 로직에 접근해 처리할 수 있도록** `findByName()`에 `Lock`을 적용했습니다.
```java

public interface ProductRepository extends JpaRepository<Product, Long> {
    ...
    @Lock(LockModeType.PESSIMISTIC_WRITE)
    Optional<Product> findByName(String name);
}
```
- [fix: 상품 조회 메소드 Lock 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/d4f7ce3d7ac78bc1058a2839d40fefe8243681f1)

### Producer 설정 클래스 정의
Producer 세부 설정을 위해 설정 클래스 `KafkaTemplateConfig`를 정의했습니다.
```java
@Configuration
public class KafkaTemplateConfig {

    @Bean
    public KafkaTemplate<String, String> customKafkaTemplate() {
        ...
        props.put(ProducerConfig.ACKS_CONFIG, "all");
        props.put(ProducerConfig.REQUEST_TIMEOUT_MS_CONFIG, "3000");
        ...
    }
}
```
- `ACKS_CONFIG` → `all` : 보낸 메시지를 leader, follower 모두 받았는지 확인 (손실↓)
- `REQUEST_TIMEOUT_MS_CONFIG` : 요청 후 응답이 도착할 때까지 기다리는 시간
- [feat: kafka producer configuration 등록](https://github.com/YeolJyeongKong/fittering-BE/commit/6ad66cf78f6d5b2fd240eba8f0fd7a70a3e403db)
- 📄  [Kafka 공식 문서 : Broker Configs](https://kafka.apache.org/documentation/#brokerconfigs)

## ML 모델 벡터에 새 상품 정보만 반영
DB 동기화 후 반영된 새 상품에 대해서 ML 모델 벡터에 업데이트를 해줘야 핏터링 서비스 내 **추천 기능 응답 후보군에 포함시킬 수 있습니다.**
하지만 기존 로직에서는 새 상품에 대해서만 업데이트하지 않고 모든 상품에 대해서 진행하고 있었으며, 요청 값으로 운영 DB에 속한 상품 ID가 아닌 **크롤링 DB 내 상품 ID를 활용하고 있었습니다.**

운영 DB에 반영된 새 상품 ID 리스트를 요청으로 보내도록 수정했습니다. 다음 코드는 해당 APi를 호출하는 로직입니다.
```java
@Scheduled(fixedDelay = DAY)
public void updateMLVector() {
   ...
    URI uri = UriComponentsBuilder.fromUriString(ML_VECTOR_UPDATE_API)
            .build()
            .toUri();
    ProductIdsDto productIdsDto = ProductIdsDto.builder()
            .product_ids(newProductList) //새 상품 ID List
            .build();

    //ML 모델 벡터 업데이트 API 호출
    restTemplate.postForObject(uri, productIdsDto, String.class);
}
```
- [fix: 새 상품만 ML 모델 벡터에 업데이트](https://github.com/YeolJyeongKong/fittering-BE/commit/3413436b242a133110a8720440e841617f740fd4)
- 트러블 슈팅
  + `InvalidDataAccessApiUsageException: Query requires transaction be in progress`
      - [fix: Lock 적용 메소드 로직에](https://github.com/YeolJyeongKong/fittering-BE/pull/120/commits/88258c19078fecff2eba9e604d9c5455ca6c56f1) @transactional [적용](https://github.com/YeolJyeongKong/fittering-BE/pull/120/commits/88258c19078fecff2eba9e604d9c5455ca6c56f1)

## 📄 세부 내용 정리
- [[Spring] Kafka 세부 설정하기](https://yooniversal.github.io/project/post265/)
- [[Spring] InvalidDataAccessApiUsageException: Query requires transaction be in progress](https://yooniversal.github.io/project/post266/)