### PR TITLE
API 수정 : 비밀번호 수정 시 HTTP 응답 변경 및 트랜잭션 적용

### DIFF
--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -104,7 +104,7 @@ public class UserController {
             userService.setPassword(userId, newPassword);
             return new ResponseEntity<>("비밀번호 변경 성공", HttpStatus.OK);
         }
-        return new ResponseEntity<>("현재 비밀번호 인증 실패", HttpStatus.UNAUTHORIZED);
+        return new ResponseEntity<>("현재 비밀번호 인증 실패", HttpStatus.BAD_REQUEST);
     }
 
     @Operation(summary = "체형 정보 조회")

--- a/src/main/java/fittering/mall/service/UserService.java
+++ b/src/main/java/fittering/mall/service/UserService.java
@@ -82,6 +82,7 @@ public class UserService {
         return passwordEncoder.matches(inputPassword, password);
     }
 
+    @Transactional
     public void setPassword(Long userId, String newPassword) {
         User user = findById(userId);
         user.setPassword(passwordEncoder.encode(newPassword));


### PR DESCRIPTION
## API 수정
### 비밀번호 수정 시 HTTP 응답 변경
비밀번호 수정 API 사용 시 사용자의 `email`과 `password`를 input으로 받아 현재 회원 정보와 일치하는지 확인하는 로직이 있습니다.
현재 회원 정보와 일치하지 않을 시 기존에는 `401 UNAUTHORIZED`가 응답 코드로 나갔으나 프론트엔드에서 `401`로 응답을 받으면
**JWT 토큰 인증 로직에서 `401` 응답에 대해 처리하는 부분**으로 넘어가 잘못된 동작을 하는 경우가 있음을 확인했습니다.
때문에 `401 UNAUTHORIZED`에서 **`400 BAD REQUEST`로 수정**했습니다.
```java
@PostMapping("/users/password/check/{password}/{newPassword}")
public ResponseEntity<?> checkPassword(@PathVariable("password") @NotEmpty String password,
                                       @PathVariable("newPassword") @NotEmpty String newPassword,
                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
    Long userId = principalDetails.getUser().getId();
    if(userService.passwordCheck(userId, password)) {
        userService.setPassword(userId, newPassword);
        return new ResponseEntity<>("비밀번호 변경 성공", HttpStatus.OK);
    }
    //HttpStatus.UNAUTHORIZED -> HttpStatus.BAD_REQUEST
    return new ResponseEntity<>("현재 비밀번호 인증 실패", HttpStatus.BAD_REQUEST);
}
```

### 트랜잭션 적용
비밀번호 수정 API 호출 시, 현재 회원 정보와 일치하면 비밀번호 수정 로직인 `setPassword()`를 호출합니다.
해당 함수에는 수정한 결과를 DB에 반영하는 로직이 포함되기 때문에 **트랜잭션이 반드시 포함돼야 하나**,
그렇지 않아서 DB에 반영되지 않는 문제가 있었습니다. 이에 대해 수정했습니다.
```java
@Transactional //추가
public void setPassword(Long userId, String newPassword) {
    User user = findById(userId);
    user.setPassword(passwordEncoder.encode(newPassword));
}
```