### PR TITLE
API 수정 : 연관검색어 응답 정보 추가

### DIFF
--- a/src/main/java/fittering/mall/controller/dto/response/ResponseReleatedSearchDto.java
+++ b/src/main/java/fittering/mall/controller/dto/response/ResponseReleatedSearchDto.java
@@ -5,13 +5,12 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import java.util.List;
-
 @Getter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ResponseRelatedSearchDto {
-    private List<ResponseReleatedSearchDto> products;
-    private List<ResponseReleatedSearchDto> malls;
+public class ResponseReleatedSearchDto {
+    private Long id;
+    private String name;
+    private String image;
 }

--- a/src/main/java/fittering/mall/domain/mapper/MallMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/MallMapper.java
@@ -4,11 +4,8 @@ import fittering.mall.config.kafka.domain.dto.CrawledMallDto;
 import fittering.mall.controller.dto.request.RequestMallDto;
 import fittering.mall.controller.dto.request.RequestMallRankProductDto;
 import fittering.mall.controller.dto.response.*;
-import fittering.mall.service.dto.MallNameAndIdDto;
-import fittering.mall.service.dto.MallPreviewDto;
+import fittering.mall.service.dto.*;
 import fittering.mall.repository.dto.SavedMallPreviewDto;
-import fittering.mall.service.dto.MallDto;
-import fittering.mall.service.dto.MallRankProductDto;
 import fittering.mall.domain.entity.Mall;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
@@ -31,4 +28,5 @@ public interface MallMapper {
     MallPreviewDto toMallPreviewDto(SavedMallPreviewDto savedMallPreviewDto);
     ResponseMallPreviewDto toResponseMallPreviewDto(MallPreviewDto mallPreviewDto, Boolean isFavorite);
     ResponseMallNameAndIdDto toResponseMallNameAndIdDto(MallNameAndIdDto mallNameAndIdDto);
+    ResponseReleatedSearchDto toResponseReleatedSearchDto(RelatedSearchDto relatedSearchDto);
 }

--- a/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/ProductMapper.java
@@ -3,8 +3,10 @@ package fittering.mall.domain.mapper;
 import fittering.mall.config.kafka.domain.dto.CrawledProductDto;
 import fittering.mall.controller.dto.request.RequestProductDetailDto;
 import fittering.mall.controller.dto.response.ResponseProductDescriptionDto;
+import fittering.mall.controller.dto.response.ResponseReleatedSearchDto;
 import fittering.mall.service.dto.ProductDescriptionDto;
 import fittering.mall.domain.entity.*;
+import fittering.mall.service.dto.RelatedSearchDto;
 import org.mapstruct.Mapper;
 import org.mapstruct.Mapping;
 import org.mapstruct.Mappings;
@@ -41,4 +43,6 @@ public interface ProductMapper {
     ProductDescription toProductDescription(String productDescription);
 
     ResponseProductDescriptionDto toResponseProductDescriptionDto(ProductDescriptionDto productDescription);
+
+    ResponseReleatedSearchDto toResponseReleatedSearchDto(RelatedSearchDto relatedSearchDto);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryCustom.java
@@ -2,12 +2,13 @@ package fittering.mall.repository.querydsl;
 
 import fittering.mall.controller.dto.response.ResponseProductPreviewDto;
 import fittering.mall.service.dto.MallNameAndIdDto;
+import fittering.mall.service.dto.RelatedSearchDto;
 
 import java.util.List;
 
 public interface MallRepositoryCustom {
     List<ResponseProductPreviewDto> findProducts(String mallName);
     Long findFavoriteCount(Long mallId);
-    List<String> relatedSearch(String keyword);
+    List<RelatedSearchDto> relatedSearch(String keyword);
     List<MallNameAndIdDto> findMallNameAndIdList();
 }

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
@@ -5,6 +5,8 @@ import fittering.mall.controller.dto.response.QResponseProductPreviewDto;
 import fittering.mall.controller.dto.response.ResponseProductPreviewDto;
 import fittering.mall.service.dto.MallNameAndIdDto;
 import fittering.mall.service.dto.QMallNameAndIdDto;
+import fittering.mall.service.dto.QRelatedSearchDto;
+import fittering.mall.service.dto.RelatedSearchDto;
 import jakarta.persistence.EntityManager;
 
 import java.util.List;
@@ -56,9 +58,13 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
     }
 
     @Override
-    public List<String> relatedSearch(String keyword) {
+    public List<RelatedSearchDto> relatedSearch(String keyword) {
         return queryFactory
-                .select(mall.name)
+                .select(new QRelatedSearchDto(
+                        mall.id.as("id"),
+                        mall.name.as("name"),
+                        mall.image.as("image")
+                ))
                 .from(mall)
                 .where(
                         mall.name.contains(keyword)

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryCustom.java
@@ -1,10 +1,7 @@
 package fittering.mall.repository.querydsl;
 
 import fittering.mall.controller.dto.response.ResponseProductPreviewDto;
-import fittering.mall.service.dto.BottomProductDto;
-import fittering.mall.service.dto.DressProductDto;
-import fittering.mall.service.dto.OuterProductDto;
-import fittering.mall.service.dto.TopProductDto;
+import fittering.mall.service.dto.*;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
@@ -17,7 +14,7 @@ public interface ProductRepositoryCustom {
     Page<ResponseProductPreviewDto> productWithCategory(Long mallId, Long categoryId, String gender, Long filterId, Pageable pageable);
     Page<ResponseProductPreviewDto> productWithSubCategory(Long mallId, Long subCategoryId, String gender, Long filterId, Pageable pageable);
     Page<ResponseProductPreviewDto> searchProduct(String productName, String gender, Long filterId, Pageable pageable);
-    List<String> relatedSearch(String keyword);
+    List<RelatedSearchDto> relatedSearch(String keyword);
     Long productCountWithCategory(Long categoryId);
     Long productCountWithSubCategory(Long categoryId);
     Long productCountWithCategoryOfMall(String mallName, Long categoryId);

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -196,9 +196,13 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     }
 
     @Override
-    public List<String> relatedSearch(String keyword) {
+    public List<RelatedSearchDto> relatedSearch(String keyword) {
         return queryFactory
-                .select(product.name)
+                .select(new QRelatedSearchDto(
+                        product.id.as("id"),
+                        product.name.as("name"),
+                        product.image.as("image")
+                ))
                 .from(product)
                 .where(
                         product.name.contains(keyword)

--- a/src/main/java/fittering/mall/service/SearchService.java
+++ b/src/main/java/fittering/mall/service/SearchService.java
@@ -1,7 +1,11 @@
 package fittering.mall.service;
 
 import fittering.mall.controller.dto.response.ResponseProductPreviewDto;
+import fittering.mall.controller.dto.response.ResponseReleatedSearchDto;
+import fittering.mall.domain.mapper.MallMapper;
+import fittering.mall.domain.mapper.ProductMapper;
 import fittering.mall.repository.MallRepository;
+import fittering.mall.service.dto.RelatedSearchDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.cache.annotation.Cacheable;
 import org.springframework.data.domain.Pageable;
@@ -9,6 +13,7 @@ import org.springframework.stereotype.Service;
 import fittering.mall.domain.RestPage;
 import fittering.mall.repository.ProductRepository;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -24,12 +29,22 @@ public class SearchService {
     }
 
     @Cacheable(value = "RelatedSearch", key = "'product_' + #keyword")
-    public List<String> relatedSearchProducts(String keyword) {
-        return productRepository.relatedSearch(keyword);
+    public List<ResponseReleatedSearchDto> relatedSearchProducts(String keyword) {
+        List<ResponseReleatedSearchDto> responseReleatedSearchDtos = new ArrayList<>();
+        List<RelatedSearchDto> relatedSearchDtos = productRepository.relatedSearch(keyword);
+        relatedSearchDtos.forEach(relatedSearchDto ->
+            responseReleatedSearchDtos.add(ProductMapper.INSTANCE.toResponseReleatedSearchDto(relatedSearchDto))
+        );
+        return responseReleatedSearchDtos;
     }
 
     @Cacheable(value = "RelatedSearch", key = "'mall_' + #keyword")
-    public List<String> relatedSearchMalls(String keyword) {
-        return mallRepository.relatedSearch(keyword);
+    public List<ResponseReleatedSearchDto> relatedSearchMalls(String keyword) {
+        List<ResponseReleatedSearchDto> responseReleatedSearchDtos = new ArrayList<>();
+        List<RelatedSearchDto> relatedSearchDtos = mallRepository.relatedSearch(keyword);
+        relatedSearchDtos.forEach(relatedSearchDto ->
+                responseReleatedSearchDtos.add(MallMapper.INSTANCE.toResponseReleatedSearchDto(relatedSearchDto))
+        );
+        return responseReleatedSearchDtos;
     }
 }

--- a/src/main/java/fittering/mall/service/dto/RelatedSearchDto.java
+++ b/src/main/java/fittering/mall/service/dto/RelatedSearchDto.java
@@ -1,0 +1,22 @@
+package fittering.mall.service.dto;
+
+import com.querydsl.core.annotations.QueryProjection;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@Builder
+@NoArgsConstructor
+public class RelatedSearchDto {
+    private Long id;
+    private String name;
+    private String image;
+
+    @QueryProjection
+    public RelatedSearchDto(Long id, String name, String image) {
+        this.id = id;
+        this.name = name;
+        this.image = image;
+    }
+}


### PR DESCRIPTION
## API 수정
### 연관검색어 응답 정보 추가
연관검색어 API 응답에서 `products`, `malls`에 대한 정보 추가했습니다.
변경 전에는 상품/쇼핑몰의 이름만 있었으나 **ID**가 없으면 해당 상품/쇼핑몰로의 이동이 불가능하기 때문에 추가했으며,
**이미지** 정보도 추가해 연관검색어 조회 시 보다 풍부한 정보를 확인할 수 있도록 했습니다.

다음은 상품/쇼핑몰에 대해 새롭게 정의한 DTO로, 서로 같은 필드를 갖습니다.
```java
public class ResponseReleatedSearchDto {
    private Long id;
    private String name;
    private String image;
}
```
- [feat: 연관검색어 상품 및 쇼핑몰 DTO 정의](https://github.com/YeolJyeongKong/fittering-BE/commit/e1ace7a9f412bd370ec7ded8deda8b0176b8f728)

Service와 Controller 즉, 레벨별로 사용하는 DTO가 분리돼 있어 **MapStruct**로 DTO 변환했습니다.
이외에는 정의한 DTO 통해 API 응답으로 나갈 수 있도록 로직을 수정했습니다.
- [feat: 연관검색어 DTO Mapper 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/47b52f15f94970dae4c88a229fb31a9a973d3e33)
- [feat: 연관검색어 DTO 응답 정보 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/ec296f0428bfe233224393d0a65abb122367c6f6)