### PR TITLE
버그 수정 : DB 내 상품 정보 저장 이슈

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -182,7 +182,10 @@ public class ProductController {
         Product product = productService.findById(productId);
         productService.updateView(productId);
         rankService.updateViewOnMall(principalDetails.getUser().getId(), product.getMall().getId());
-        userService.saveRecentProduct(principalDetails.getUser().getId(), productId);
+
+        if (!userService.isRecentProduct(principalDetails.getUser().getId(), productId)) {
+            userService.saveRecentProduct(principalDetails.getUser().getId(), productId);
+        }
 
         if(product.getType().equals(OUTER)) {
             ResponseOuterDto outerProduct = productService.outerProductDetail(principalDetails.getUser().getId(), productId);

--- a/src/main/java/fittering/mall/repository/querydsl/RecentRepositoryCustom.java
+++ b/src/main/java/fittering/mall/repository/querydsl/RecentRepositoryCustom.java
@@ -13,4 +13,5 @@ public interface RecentRepositoryCustom {
     Page<ResponseProductPreviewDto> recentProduct(Long userId, Pageable pageable);
     void initializeRecents(Long userId);
     List<Long> recentProductIds(Long userId);
+    Boolean isRecentProduct(Long userId, Long productId);
 }

--- a/src/main/java/fittering/mall/repository/querydsl/RecentRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/RecentRepositoryImpl.java
@@ -15,6 +15,7 @@ import static fittering.mall.domain.entity.QMall.mall;
 import static fittering.mall.domain.entity.QProduct.product;
 import static fittering.mall.domain.entity.QRecent.recent;
 import static fittering.mall.domain.entity.QUser.user;
+import static fittering.mall.repository.querydsl.EqualMethod.productIdEq;
 import static fittering.mall.repository.querydsl.EqualMethod.userIdEq;
 
 public class RecentRepositoryImpl implements RecentRepositoryCustom {
@@ -130,5 +131,19 @@ public class RecentRepositoryImpl implements RecentRepositoryCustom {
                         userIdEq(userId)
                 )
                 .fetch();
+    }
+
+    @Override
+    public Boolean isRecentProduct(Long userId, Long productId) {
+        return queryFactory
+                .select()
+                .from(recent)
+                .leftJoin(recent.user, user)
+                .leftJoin(recent.product, product)
+                .where(
+                        userIdEq(userId),
+                        productIdEq(productId)
+                )
+                .fetchFirst() != null;
     }
 }

--- a/src/main/java/fittering/mall/service/UserService.java
+++ b/src/main/java/fittering/mall/service/UserService.java
@@ -129,6 +129,10 @@ public class UserService {
                                         .build());
     }
 
+    public boolean isRecentProduct(Long userId, Long productId) {
+        return recentRepository.isRecentProduct(userId, productId);
+    }
+
     public User login(LoginDto loginDto) {
         Optional<User> optionalUser = userRepository.findByEmail(loginDto.getEmail());
         if (optionalUser.isEmpty()) {


### PR DESCRIPTION
## 버그 수정
### DB 내 상품 정보 저장 이슈
핏터링 서비스에서는 사용자가 상품을 조회하면 최근 본 상품 기능에서 다시 조회할 수 있도록 상품 정보를 추가하고 있습니다.
상품 정보 갱신은 정상적으로 동작하지만, **이미 저장된 상품이 다시 추가되어 중복 상품이 저장되는 이슈가 있었습니다.**
내부 로직을 확인해보니 상품 조회할 때마다 최근 본 상품에 추가하도록 동작하고 있었고, 이미 저장된 상품이면 추가하지 않도록 예외 처리했습니다.
```java
@GetMapping("/auth/products/{productId}")
public ResponseEntity<?> productDetail(@PathVariable("productId") @NotEmpty Long productId,
                                       @AuthenticationPrincipal PrincipalDetails principalDetails) {
    Product product = productService.findById(productId);

    //해당 상품이 최근 본 상품 목록에 이미 존재한다면 추가하지 않음
    if (!userService.isRecentProduct(principalDetails.getUser().getId(), productId)) {
        userService.saveRecentProduct(principalDetails.getUser().getId(), productId);
    }
    ...
}
```
- [fix: 상품 조회 시 최근 본 상품 기록에 없을 때만 기록 갱신하도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/2b26996df2b17742d2c0bd92416bcf834069ce50)

### To do
최근 본 상품에 있는 상품이 등록되지 않도록 설정했으나 추후에는 이미 등록된 상품 조회 시 가장 앞으로 가져오도록 수정 예정입니다.