### PR TITLE
API 수정 : 체형 스마트 분석에서 잘못된 응답 및 request 필드 타입 수정

### DIFF
--- a/src/main/java/fittering/mall/controller/UserController.java
+++ b/src/main/java/fittering/mall/controller/UserController.java
@@ -209,7 +209,7 @@ public class UserController {
     }
 
     @Operation(summary = "체형 스마트 분석")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMeasurementDto.class))))
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMeasurementDto.class)))
     @PostMapping("/users/recommendation/measurement")
     public ResponseEntity<?> recommendMeasurement(@RequestBody @Valid RequestSmartMeasurementDto requestSmartMeasurementDto,
                                                   BindingResult bindingResult) {

--- a/src/main/java/fittering/mall/controller/dto/request/RequestSmartMeasurementDto.java
+++ b/src/main/java/fittering/mall/controller/dto/request/RequestSmartMeasurementDto.java
@@ -12,9 +12,9 @@ public class RequestSmartMeasurementDto {
     @NonNull
     private String side;
     @NonNull
-    private Integer height;
+    private Double height;
     @NonNull
-    private Integer weight;
+    private Double weight;
     @NonNull
     private String sex;
 }


### PR DESCRIPTION
# API 수정
## 체형 스마트 분석 API
### Swagger 응답 수정
기존 Swagger 문서에서 체형 스마트 분석 API의 응답이 `Array` 타입으로 나가도록 설정돼 있었습니다.
다음은 변경 전 Swagger에 등록돼 있던 **잘못된 응답 예시**입니다.
```
[
  {
    "height": 0,
    "weight": 0,
    "arm": 0,
    "leg": 0,
    "shoulder": 0,
    "waist": 0,
    "chest": 0,
    "thigh": 0,
    "hip": 0
  }
]
```

`Array` 타입이 아닌 `ResponseMeasurementDto` 객체 1개만 응답으로 나가는게 맞으므로 **`@ArraySchema`를 제거**해 수정했습니다.
```java
@Operation(summary = "체형 스마트 분석")
@ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseMeasurementDto.class)))
@PostMapping("/users/recommendation/measurement")
public ResponseEntity<?> recommendMeasurement(@RequestBody @Valid RequestSmartMeasurementDto requestSmartMeasurementDto, BindingResult bindingResult)
{...}
```
<br>

- [fix: Swagger 문서 내 체형 스마트 분석 API 응답 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/02d1bf2d0b93b3c3c3c173bee091ca91e8eef918)

### Request 필드 타입 수정
핏터링 서비스에서는 사용자 체형 정보에 대한 모든 정보를 정수형 타입인 **`Double`로 설정하고 있습니다.**
하지만 체형 스마트 분석 API 요청 타입 `RequestSmartMeasurementDto`에서 일부 필드가 `Integer` 타입을 사용중이어서 수정했습니다.
```java
public class RequestSmartMeasurementDto {
    private String front;
    private String side;
    private Double height; //Integer -> Double
    private Double weight; //Integer -> Double
    private String sex;
}
```
- [fix: 체형 스마트 분석 API 요청 내 잚못된 필드 타입 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/5ead3e35c1541d640aa9ee150cbdf83c2587fd44)