### PR TITLE
API 수정 : 연관검색어, 쇼핑몰 랭킹

### DIFF
--- a/src/main/java/fittering/mall/controller/SearchController.java
+++ b/src/main/java/fittering/mall/controller/SearchController.java
@@ -23,14 +23,14 @@ import fittering.mall.service.SearchService;
 @Tag(name = "검색", description = "검색 서비스 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1")
 public class SearchController {
 
     private final SearchService searchService;
 
     @Operation(summary = "검색")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(schema = @Schema(implementation = ResponseProductPreviewDto.class)))
-    @GetMapping("/search/{keyword}/{gender}/{filterId}")
+    @GetMapping("/auth/search/{keyword}/{gender}/{filterId}")
     public ResponseEntity<?> search(@PathVariable("keyword") @NotEmpty String keyword,
                                     @PathVariable("gender") @NotEmpty String gender,
                                     @PathVariable("filterId") @NotEmpty Long filterId,

--- a/src/main/java/fittering/mall/controller/dto/response/ResponseMallRankProductDto.java
+++ b/src/main/java/fittering/mall/controller/dto/response/ResponseMallRankProductDto.java
@@ -12,4 +12,5 @@ import lombok.NoArgsConstructor;
 public class ResponseMallRankProductDto {
     private Long productId;
     private String productImage;
+    private String productName;
 }

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
@@ -19,6 +19,8 @@ import static fittering.mall.repository.querydsl.EqualMethod.mallNameEq;
 
 public class MallRepositoryImpl implements MallRepositoryCustom {
 
+    private static final int RELATED_PRODUCTS_COUNT = 8;
+
     private JPAQueryFactory queryFactory;
 
     public MallRepositoryImpl(EntityManager em) {
@@ -69,6 +71,7 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
                 .where(
                         mall.name.contains(keyword)
                 )
+                .limit(RELATED_PRODUCTS_COUNT)
                 .fetch();
     }
 

--- a/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/MallRepositoryImpl.java
@@ -19,7 +19,7 @@ import static fittering.mall.repository.querydsl.EqualMethod.mallNameEq;
 
 public class MallRepositoryImpl implements MallRepositoryCustom {
 
-    private static final int RELATED_PRODUCTS_COUNT = 8;
+    private static final int RELATED_MALLS_COUNT = 8;
 
     private JPAQueryFactory queryFactory;
 
@@ -71,7 +71,7 @@ public class MallRepositoryImpl implements MallRepositoryCustom {
                 .where(
                         mall.name.contains(keyword)
                 )
-                .limit(RELATED_PRODUCTS_COUNT)
+                .limit(RELATED_MALLS_COUNT)
                 .fetch();
     }
 

--- a/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/ProductRepositoryImpl.java
@@ -43,6 +43,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
     private static final int TIME_RANK_PRODUCT_COUNT = 18;
     private static final int AGE_RANGE_SIZE = 6;
     private static final int GENDER_SIZE = 2;
+    private static final int RELATED_PRODUCTS_COUNT = 8;
 
     private JPAQueryFactory queryFactory;
 
@@ -207,6 +208,7 @@ public class ProductRepositoryImpl implements ProductRepositoryCustom {
                 .where(
                         product.name.contains(keyword)
                 )
+                .limit(RELATED_PRODUCTS_COUNT)
                 .fetch();
     }
 

--- a/src/main/java/fittering/mall/service/RankService.java
+++ b/src/main/java/fittering/mall/service/RankService.java
@@ -107,6 +107,7 @@ public class RankService {
             productDtos.add(ResponseMallRankProductDto.builder()
                     .productId(product.getId())
                     .productImage(product.getImage())
+                    .productName(product.getName())
                     .build());
         }
     }


### PR DESCRIPTION
## API 수정
### 연관검색어
연관검색어 기능은 사용자의 권한이 필요하지 않습니다. **즉, 사용자에 따라 반환되는 내용이 달라지지 않습니다.**
때문에 토큰을 사용하지 않는 API이므로 URI에서 `/auth`를 제거했습니다.
- [fix: 연관검색어 API 토큰 사용 비활성화](https://github.com/YeolJyeongKong/fittering-BE/commit/991510daf7439e9fcdec58b7288ce59663ce9991)

### 커스텀 쇼핑몰 랭킹
쇼핑몰 정보 하단에 있을 미리보기 상품 정보에 **상품명**을 추가했습니다.
필드명은 `productName`으로 설정했습니다.
```java
public class ResponseMallRankProductDto {
    private Long productId;
    private String productImage;
    private String productName; //추가
}
```
- [fix: 쇼핑몰 랭킹 내 상품 DTO에 이름 필드 추가](https://github.com/YeolJyeongKong/fittering-BE/commit/08281bdb2fcfd44cd3d8f90b2bff23d426fc29ff)

### 최대 개수
기존에는 불러오는 연관 상품 개수에 대한 제한이 없었으나, 팀 내 회의를 통해 일부 상품만 노출시키는게
UI면에서 좋은 경험을 제공할 수 있을 것이라 판단해 최대 **8개**만 노출하도록 설정했습니다.
```java
public List<RelatedSearchDto> relatedSearch(String keyword) {
    return queryFactory
            .select(new QRelatedSearchDto(
                    mall.id.as("id"),
                    mall.name.as("name"),
                    mall.image.as("image")
            ))
            .from(mall)
            .where(
                    mall.name.contains(keyword)
            )
            .limit(RELATED_MALLS_COUNT) //노출 쇼핑물 최대 8개 설정
            .fetch();
}

public List<RelatedSearchDto> relatedSearch(String keyword) {
    return queryFactory
            .select(new QRelatedSearchDto(
                    product.id.as("id"),
                    product.name.as("name"),
                    product.image.as("image")
            ))
            .from(product)
            .where(
                    product.name.contains(keyword)
            )
            .limit(RELATED_PRODUCTS_COUNT) //노출 상품 최대 8개 설정
            .fetch();
}
```
- [fix: 연관검색어 상품 반환 최대 개수 설정](https://github.com/YeolJyeongKong/fittering-BE/commit/b7c43021ba5f6775fa33526210789923b421c669)