### PR TITLE
API 수정 : 메일 관련 API 권한 체크 해제

### DIFF
--- a/src/main/java/fittering/mall/controller/MailController.java
+++ b/src/main/java/fittering/mall/controller/MailController.java
@@ -20,7 +20,7 @@ import static fittering.mall.controller.ControllerUtils.isInvalidEmail;
 @Tag(name = "메일", description = "비밀번호 찾기 서비스 관련 API")
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/v1/auth")
+@RequestMapping("/api/v1")
 public class MailController {
 
     private final UserService userService;


### PR DESCRIPTION
## API 수정
### 메일 관련 API 권한 체크 해제
로그인하지 않은 사용자가 이용하는 API인  **메일 검증** 및 **비밀번호 찾기** 기능은 메인 페이지에 접근할 수 없는 즉, **권한이 없는 사용자**이기 때문에
권한이 없어도 해당 API를 이용할 수 있어야 합니다. 하지만 권한을 검증하도록 URI가 설정돼 있어 수정했습니다.
```java
@PostMapping("/api/v1/email/check")
public ResponseEntity<?> checkEmail(@RequestParam("email") String email) { ... }

@PostMapping("/api/v1/password/send")
public ResponseEntity<?> sendPassword(@RequestParam("email") String email) { ... }
```
- [fix: 메일 API 권한 검증하지 않도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/75707ef81b7f89ae0e71ad33f33a87077b92d911)