### PR TITLE
버그 수정 : 이메일 형식 검증 안됨

### DIFF
--- a/src/main/java/fittering/mall/controller/ControllerUtils.java
+++ b/src/main/java/fittering/mall/controller/ControllerUtils.java
@@ -18,6 +18,6 @@ public class ControllerUtils {
     }
 
     public static boolean isInvalidEmail(String email) {
-        return email.matches("^[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\\.[a-zA-Z]{2,}$");
+        return email.matches("[0-9a-zA-Z]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
     }
 }

--- a/src/main/java/fittering/mall/controller/ControllerUtils.java
+++ b/src/main/java/fittering/mall/controller/ControllerUtils.java
@@ -18,6 +18,6 @@ public class ControllerUtils {
     }
 
     public static boolean isInvalidEmail(String email) {
-        return email.matches("[0-9a-zA-Z]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
+        return !email.matches("[0-9a-zA-Z]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
     }
 }


### PR DESCRIPTION
## 버그 수정
### 이메일 형식 검증
비밀번호 찾기 API에서 입력한 이메일이 DB에 존재하는지 체크하고, 존재한다면 해당 이메일로 임시 비밀번호를 발급합니다.
여기서 입력한 이메일 형식이 올바른지 항상 검증을 하고 있으며, 해당 과정은 `isInvalidEmail()`에서 이뤄집니다.
정상적인 이메일을 입력해도 **기존 정규표현식**을 통과하지 못했고, **잘못된 로직**이 포함돼 있어 이에 대해 적절히 수정했습니다.
```java
public static boolean isInvalidEmail(String email) {
    return !email.matches("[0-9a-zA-Z]+(.[_a-z0-9-]+)*@(?:\\w+\\.)+\\w+$");
}
```
- [fix: 이메일 형식 검증 정규표현식 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/e110ecc6443731d43187648ef501e12958098be0)
- [fix: 잘못된 이메일 검증 로직 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/5d672c8085523dcc63b65192b9b4ac86c611e85c)