### PR TITLE
버그 수정 : 상품 상세 조회 시 recent 정보 확인 안됨

### DIFF
--- a/src/main/java/fittering/mall/repository/querydsl/RecentRepositoryImpl.java
+++ b/src/main/java/fittering/mall/repository/querydsl/RecentRepositoryImpl.java
@@ -135,8 +135,8 @@ public class RecentRepositoryImpl implements RecentRepositoryCustom {
 
     @Override
     public Boolean isRecentProduct(Long userId, Long productId) {
-        return queryFactory
-                .select()
+        Long recentProductCount = queryFactory
+                .select(recent.count())
                 .from(recent)
                 .leftJoin(recent.user, user)
                 .leftJoin(recent.product, product)
@@ -144,6 +144,7 @@ public class RecentRepositoryImpl implements RecentRepositoryCustom {
                         userIdEq(userId),
                         productIdEq(productId)
                 )
-                .fetchFirst() != null;
+                .fetchOne();
+        return recentProductCount != null;
     }
 }


### PR DESCRIPTION
## 버그 수정
### 상품 상세 조회 시 recent 정보 확인 안됨
> org.springframework.dao.**InvalidDataAccessApiUsageException**: org.hibernate.query.sqm.ParsingException: line 2:12 mismatched input 'recent' expecting {<EOF>, ',', FROM, GROUP, ORDER, WHERE}]

상품 상세 조회할 때마다 현재 `user`의 `recent`에 해당 상품 정보가 있는지 확인하기 위해 `userService.isRecentProduct()`를 호출하는데, **저장된 recent 정보가 없을 때** `InvalidDataAccessApiUsageException`이 발생했습니다. 때문에 상품 상세 정보를 정상적으로 불러오지 못하는 문제가 있었습니다.

기존 코드에서는 빠른 조회를 위해 `fetchFirst() != null`를 적용했으나, 여기서 예외가 발생했습니다.
```java
public Boolean isRecentProduct(Long userId, Long productId) {
    return queryFactory
            .select()
            .from(recent)
            .leftJoin(recent.user, user)
            .leftJoin(recent.product, product)
            .where(
                    userIdEq(userId),
                    productIdEq(productId)
            )
            .fetchFirst() != null; //InvalidDataAccessApiUsageException 발생
}
```

`fetchOne() != null`로 수정해 해결했습니다.
- [fix: recent 정보 없을 때 처리](https://github.com/YeolJyeongKong/fittering-BE/commit/84440ab5a04392d4e8a8078744751664712d14aa)