### PR TITLE
버그 수정 : 조회수 업데이트 되지 않음

### DIFF
--- a/src/main/java/fittering/mall/config/cache/CacheConfig.java
+++ b/src/main/java/fittering/mall/config/cache/CacheConfig.java
@@ -14,6 +14,8 @@ import java.time.Duration;
 @Configuration
 public class CacheConfig {
 
+    private static final int TWENTY_FIVE_HOURS = 3600 * 25;
+
     /**
      * Spring Boot가 기본적으로 RedisCacheManager를 자동 설정해줘서 RedisCacheConfiguration 없어도 사용 가능
      * Bean을 새로 선언하면 직접 설정한 RedisCacheConfiguration 이 적용됨
@@ -21,7 +23,7 @@ public class CacheConfig {
     @Bean
     public RedisCacheConfiguration redisCacheConfiguration() {
         return RedisCacheConfiguration.defaultCacheConfig()
-                .entryTtl(Duration.ofSeconds(3600))
+                .entryTtl(Duration.ofSeconds(TWENTY_FIVE_HOURS))
                 .disableCachingNullValues()
                 .serializeKeysWith(
                         RedisSerializationContext.SerializationPair.fromSerializer(new StringRedisSerializer())

--- a/src/main/java/fittering/mall/service/RedisService.java
+++ b/src/main/java/fittering/mall/service/RedisService.java
@@ -30,7 +30,7 @@ public class RedisService {
     @Transactional
     public void batchUpdateView() {
         redisTemplate.keys("Batch:Product_view_*").forEach(key -> {
-            Long productId = Long.parseLong(key.split("_")[1]);
+            Long productId = Long.parseLong(key.split("_")[2]);
             Integer view = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());
 
             updateViewOfProduct(productId, view);
@@ -38,7 +38,7 @@ public class RedisService {
         });
 
         redisTemplate.keys("Batch:Product_timeView_*").forEach(key -> {
-            Long productId = Long.parseLong(key.split("_")[1]);
+            Long productId = Long.parseLong(key.split("_")[2]);
             Integer timeView = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());
 
             updateTimeViewOfProduct(productId, timeView);
@@ -46,7 +46,7 @@ public class RedisService {
         });
 
         redisTemplate.keys("Batch:Rank_view_*").forEach(key -> {
-            Long rankId = Long.parseLong(key.split("_")[1]);
+            Long rankId = Long.parseLong(key.split("_")[2]);
             Integer view = Integer.parseInt(redisTemplate.opsForValue().get(key).toString());
 
             updateViewOfRank(rankId, view);


### PR DESCRIPTION
# 버그 수정
## 조회수 업데이트
조회수를 기준으로 동작하는 기능 **커스텀 쇼핑몰 랭킹**, **상품 실시간 랭킹**에서 정상적으로 정렬이 안되는 문제가 있었습니다.
DB를 확인해보니 조회수 관련 필드 `view`, `timeView`가 정상적으로 업데이트되지 않는 문제가 있었고, 로그를 통해서 확인해본 결과
Redis 캐시에 저장된 정보가 Spring scheduler를 통해 처리되는 로직에서 문제가 발생했다고 판단했습니다.

### 캐시 주기 재설정
캐시에 저장된 조회수 정보가 Spring scheduler를 통해 DB에 반영되는 주기를 `view`는 **1시간**, `timeView`는 **하루**로 설정을 해놓았으나,
실제로 캐시가 정보를 유지하는 시간인 `TTL`은 1시간으로 설정돼 있었습니다. 때문에 하루보다 긴 시간인 **25시간**으로 설정했습니다.
(참고) 정상적으로 DB에 반영을 했다면 해당 정보를 캐시에서 삭제하는 작업까지 진행합니다.
```java
public class CacheConfig {

    private static final int TWENTY_FIVE_HOURS = 3600 * 25;

    @Bean
    public RedisCacheConfiguration redisCacheConfiguration() {
        return RedisCacheConfiguration.defaultCacheConfig()
                .entryTtl(Duration.ofSeconds(TWENTY_FIVE_HOURS)) //캐시 추기화 주기 25시간으로 설정
                ...
 }
```
- [fix: 캐시 주기 재설정](https://github.com/YeolJyeongKong/fittering-BE/commit/62161a376c3d017580fae4aa2b141c643918aae7)

### 정상값을 참조하도록 수정
조회수 업데이트 정보를 DB에 반영하는 로직에서 캐시에 저장한 key를 파싱하는 과정 중 **잘못된 값을 참조하는 문제가 있었습니다.**
적절한 값을 참조하도록 수정했습니다.
- [fix: cache key 파싱 대상 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/d380341269c72bf6616f35a69476b7c078701cb9)