### PR TITLE
버그 수정 : 마이페이지 수정 시 연령대가 변경되지 않는 문제

### DIFF
--- a/src/main/java/fittering/mall/domain/entity/User.java
+++ b/src/main/java/fittering/mall/domain/entity/User.java
@@ -107,6 +107,7 @@ public class User extends BaseEntity {
         year = userDto.getYear();
         month = userDto.getMonth();
         day = userDto.getDay();
+        ageRange = getAgeRange(year, month, day);
     }
 
     public void setPassword(String password) {


### PR DESCRIPTION
## 버그 수정
### 연령대 변경되지 않음
마이페이지에서 유저 생년월일 수정 시 연령대 `ageRange`가 같이 반영돼야 하는데, 생년월일만 반영되는 문제를 확인했습니다.
코드 확인 결과 최종 호출 함수인 `User.update()`에서 **`ageRange`에 대해 갱신하는 함수가 누락돼 있었습니다.**
등록된 생년월일로 `ageRange`를 계산하는 함수 `User.getAgeRange()`를 호출해 자동 갱신하도록 했습니다.
```java
public void update(UserDto userDto) {
    username = userDto.getUsername();
    gender = userDto.getGender();
    year = userDto.getYear();
    month = userDto.getMonth();
    day = userDto.getDay();
    ageRange = getAgeRange(year, month, day); //추가
}
```
- [fix: 마이페이지 수정 시 연령대 업데이트](https://github.com/YeolJyeongKong/fittering-BE/commit/534174984e069c92133e972dfb09fc74a4d80f8c)