### PR TITLE
버그 수정 : 구글/카카오 로그인 에러

### DIFF
--- a/src/main/java/fittering/mall/controller/OAuthController.java
+++ b/src/main/java/fittering/mall/controller/OAuthController.java
@@ -72,7 +72,7 @@ public class OAuthController {
 
     @GetMapping("/login/oauth/apple")
     public String loginAppleOAuth() {
-        return loginUrl(APPLE_AUTH_URL, APPLE_CLIENT_ID, APPLE_REDIRECT_URI, APPLE_RESPONSE_TYPE, APPLE_NONCE);
+        return loginUrlWithNonce(APPLE_AUTH_URL, APPLE_CLIENT_ID, APPLE_REDIRECT_URI, APPLE_RESPONSE_TYPE, APPLE_NONCE);
     }
 
     @GetMapping("/login/apple")
@@ -93,7 +93,7 @@ public class OAuthController {
 
     @GetMapping("/login/oauth/kakao")
     public String loginKakaoOAuth() {
-        return loginUrl(KAKAO_AUTH_URL, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URI, KAKAO_RESPONSE_TYPE, KAKAO_SCOPE);
+        return loginUrlWithScope(KAKAO_AUTH_URL, KAKAO_CLIENT_ID, KAKAO_REDIRECT_URI, KAKAO_RESPONSE_TYPE, KAKAO_SCOPE);
     }
 
     @GetMapping("/login/kakao")
@@ -122,7 +122,7 @@ public class OAuthController {
 
     @GetMapping("/login/oauth/google")
     public String loginGoogleOAuth() {
-        return loginUrl(GOOGLE_AUTH_URL, GOOGLE_CLIENT_ID, GOOGLE_REDIRECT_URI, GOOGLE_RESPONSE_TYPE, GOOGLE_SCOPE);
+        return loginUrlWithScope(GOOGLE_AUTH_URL, GOOGLE_CLIENT_ID, GOOGLE_REDIRECT_URI, GOOGLE_RESPONSE_TYPE, GOOGLE_SCOPE);
     }
 
     @GetMapping("/login/google")
@@ -149,12 +149,20 @@ public class OAuthController {
         return redirectWithToken(MAIN_LOGIN_URL, jwtTokenProvider.createToken(user.getEmail(), user.getRoles()));
     }
 
-    private static String loginUrl(String authUrl, String clientId, String redirectUri, String responseType, String nonce) {
+    private static String loginUrlWithNonce(String authUrl, String clientId, String redirectUri, String responseType, String nonce) {
         return "redirect:" + authUrl
                 + "?client_id=" + clientId
                 + "&redirect_uri=" + redirectUri
                 + "&response_type=" + responseType
                 + "&nonce=" + nonce;
+    }
+
+    private static String loginUrlWithScope(String authUrl, String clientId, String redirectUri, String responseType, String scope) {
+        return "redirect:" + authUrl
+                + "?client_id=" + clientId
+                + "&redirect_uri=" + redirectUri
+                + "&response_type=" + responseType
+                + "&scope=" + scope;
     }
 
     private static String redirectWithToken(String mainUrl, String token) {


### PR DESCRIPTION
# 버그 수정
## 로그인 에러
### 구글/카카오
> Missing required parameter: scope
400 오류: invalid_request

<img style="display:inline;" width="400" alt="스크린샷 2023-11-05 오후 7 53 29" src="https://github.com/YeolJyeongKong/fittering-BE/assets/61930524/8451ae1c-d536-4bc8-9da6-3d81873b33de">

<img style="display:inline;" width="315" alt="스크린샷 2023-11-05 오후 7 55 51" src="https://github.com/YeolJyeongKong/fittering-BE/assets/61930524/b1c47542-278c-400f-a441-ed538e2b4d8f">


구글/카카오 **소셜 로그인 시 필요한 파라미터 `scope`가 누락되어** 로그인에 실패하는 문제가 있었습니다.
이전 리팩토링 과정(#110)에서 공통 함수로 묶는 과정에서 발생한 것으로 보이며, 애플 로그인 시 쓰이는 파라미터명이 `nonce`로 달라서
애플 로그인은 성공하지만 구글/카카오 로그인은 되지 않는 것으로 확인했습니다. 때문에 로그인 URI를 다음처럼 분리했습니다.
```java
//apple
private static String loginUrlWithNonce(String authUrl, String clientId, String redirectUri, String responseType, String nonce) {
    return "redirect:" + authUrl
            + "?client_id=" + clientId
            + "&redirect_uri=" + redirectUri
            + "&response_type=" + responseType
            + "&nonce=" + nonce; //nonce 사용
}

//google, kakao
private static String loginUrlWithScope(String authUrl, String clientId, String redirectUri, String responseType, String scope) {
    return "redirect:" + authUrl
            + "?client_id=" + clientId
            + "&redirect_uri=" + redirectUri
            + "&response_type=" + responseType
            + "&scope=" + scope; //scope 사용
}
```
- [fix: 구글 및 카카오 로그인 시 입력되는 쿼리 파라미터 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/dd43222db4be8ad9fa85863002ae147db48609aa)