### PR TITLE
API 구현 : 쇼핑몰 전체 보기

### DIFF
--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -69,8 +69,16 @@ public class MallController {
     @Operation(summary = "쇼핑몰 이름 및 ID 리스트 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallNameAndIdDto.class))))
     @GetMapping("/malls/list")
-    public ResponseEntity<?> mallList() {
+    public ResponseEntity<?> mallNameAndIdList() {
         List<ResponseMallNameAndIdDto> mallList = mallService.findMallNameAndIdList();
+        return new ResponseEntity<>(mallList, HttpStatus.OK);
+    }
+
+    @Operation(summary = "쇼핑몰 전체 리스트 조회")
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallWithProductDto.class))))
+    @GetMapping("/malls/preview/list")
+    public ResponseEntity<?> mallList() {
+        List<ResponseMallWithProductDto> mallList = mallService.findAll();
         return new ResponseEntity<>(mallList, HttpStatus.OK);
     }
 


### PR DESCRIPTION
## API 구현
### 쇼핑몰 전체 보기
<img width="1057" alt="image" src="https://github.com/YeolJyeongKong/fittering-BE/assets/61930524/89cdd44d-c81b-4775-839d-ce293a22dce3">

신규 사용자처럼 조회한 상품/쇼핑몰 정보가 없는 경우 **쇼핑몰 전체 보기 기능**을 통해 모든 쇼핑몰 정보를 얻을 수 있도록 합니다.
해당 API는 `쇼핑몰 랭킹 조회 API`의 응답 형태인 `ResponseMallWithProductDto`과 같은 타입으로 반환합니다. (팀 내 협의)
```java
public class ResponseMallWithProductDto {
    private Long id;
    private String name;
    private String image;
    private String description;
    private Integer view;
    private Boolean isFavorite;
    private List<ResponseMallRankProductDto> products;
}
```

API 구현 함수 정보는 아래와 같습니다.
```java
@GetMapping("/malls/preview/list")
public ResponseEntity<?> mallList() {
    List<ResponseMallWithProductDto> mallList = mallService.findAll();
    return new ResponseEntity<>(mallList, HttpStatus.OK);
}
```
- API URI : `/api/v1/malls/preview/list`
- [feat: 전체 쇼핑몰 정보 가져오는 API 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/a866e00f9c86f9e178d81335616a72e645663d99)
- [feat: 전체 쇼핑몰 정보 가져오는 로직 구현](https://github.com/YeolJyeongKong/fittering-BE/commit/280f44018c4fc25048ff7159ccd7d94ff4fea766)
