### PR TITLE
API 수정 : 카테고리별 상품 개수 조회 응답 변경

### DIFF
--- a/src/main/java/fittering/mall/controller/ProductController.java
+++ b/src/main/java/fittering/mall/controller/ProductController.java
@@ -111,10 +111,10 @@ public class ProductController {
     }
 
     @Operation(summary = "카테고리별 상품 개수 조회")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductCategoryDto.class))))
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductAllCategoryDto.class))))
     @GetMapping("/categories/count")
     public ResponseEntity<?> multipleProductCountWithCategory() {
-        List<ResponseProductCategoryDto> categoryWithProductCounts = productService.multipleProductCountWithCategory();
+        ResponseProductAllCategoryDto categoryWithProductCounts = productService.multipleProductCountWithCategory();
         return new ResponseEntity<>(categoryWithProductCounts, HttpStatus.OK);
     }
 
@@ -155,10 +155,10 @@ public class ProductController {
     }
 
     @Operation(summary = "쇼핑몰 내 카테고리별 상품 개수 조회")
-    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductCategoryDto.class))))
+    @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseProductAllCategoryDto.class))))
     @GetMapping("/malls/{mallId}/categories/count")
     public ResponseEntity<?> productCountWithCategoryOfMall(@PathVariable("mallId") @NotEmpty Long mallId) {
-        List<ResponseProductCategoryDto> categoryWithProductCounts = productService.productCountWithCategoryOfMall(mallId);
+        ResponseProductAllCategoryDto categoryWithProductCounts = productService.productCountWithCategoryOfMall(mallId);
         return new ResponseEntity<>(categoryWithProductCounts, HttpStatus.OK);
     }
 

--- a/src/main/java/fittering/mall/controller/dto/response/ResponseProductAllCategoryDto.java
+++ b/src/main/java/fittering/mall/controller/dto/response/ResponseProductAllCategoryDto.java
@@ -1,0 +1,17 @@
+package fittering.mall.controller.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ResponseProductAllCategoryDto {
+    List<ResponseProductCategoryDto> main;
+    List<ResponseProductCategoryDto> sub;
+}

--- a/src/main/java/fittering/mall/controller/dto/response/ResponseProductCategoryDto.java
+++ b/src/main/java/fittering/mall/controller/dto/response/ResponseProductCategoryDto.java
@@ -10,6 +10,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ResponseProductCategoryDto {
-    private String category;
+    private Long categoryId;
     private Long count;
 }

--- a/src/main/java/fittering/mall/domain/mapper/CategoryMapper.java
+++ b/src/main/java/fittering/mall/domain/mapper/CategoryMapper.java
@@ -8,5 +8,5 @@ import org.mapstruct.factory.Mappers;
 public interface CategoryMapper {
     CategoryMapper INSTANCE = Mappers.getMapper(CategoryMapper.class);
 
-    ResponseProductCategoryDto toResponseProductCategoryDto(String category, Long count);
+    ResponseProductCategoryDto toResponseProductCategoryDto(Long categoryId, Long count);
 }

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -105,7 +105,7 @@ public class ProductService {
         List<ResponseProductCategoryDto> mainCategoryDtos = new ArrayList<>();
         categoryRepository.findAll().forEach(category -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
-                    category.getName(),
+                    category.getId(),
                     productRepository.productCountWithCategory(category.getId())
             );
             mainCategoryDtos.add(categoryDto);
@@ -114,7 +114,7 @@ public class ProductService {
         List<ResponseProductCategoryDto> subCategoryDtos = new ArrayList<>();
         subCategoryRepository.findAll().forEach(subCategory -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
-                    subCategory.getName(),
+                    subCategory.getId(),
                     productRepository.productCountWithSubCategory(subCategory.getId())
             );
             subCategoryDtos.add(categoryDto);
@@ -136,7 +136,7 @@ public class ProductService {
         List<ResponseProductCategoryDto> mainCategoryDtos = new ArrayList<>();
         categoryRepository.findAll().forEach(category -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
-                    category.getName(),
+                    category.getId(),
                     productRepository.productCountWithCategoryOfMall(mall.getName(), category.getId())
             );
             mainCategoryDtos.add(categoryDto);
@@ -145,7 +145,7 @@ public class ProductService {
         List<ResponseProductCategoryDto> subCategoryDtos = new ArrayList<>();
         subCategoryRepository.findAll().forEach(subCategory -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
-                    subCategory.getName(),
+                    subCategory.getId(),
                     productRepository.productCountWithSubCategoryOfMall(mall.getName(), subCategory.getId())
             );
             subCategoryDtos.add(categoryDto);

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -101,51 +101,62 @@ public class ProductService {
     }
 
     @Cacheable(value = "Product", key = "'count'")
-    public List<ResponseProductCategoryDto> multipleProductCountWithCategory() {
-        List<ResponseProductCategoryDto> productCategoryDtos = new ArrayList<>();
-
+    public ResponseProductAllCategoryDto multipleProductCountWithCategory() {
+        List<ResponseProductCategoryDto> mainCategoryDtos = new ArrayList<>();
         categoryRepository.findAll().forEach(category -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
                     category.getName(),
                     productRepository.productCountWithCategory(category.getId())
             );
-            productCategoryDtos.add(categoryDto);
+            mainCategoryDtos.add(categoryDto);
         });
 
+        List<ResponseProductCategoryDto> subCategoryDtos = new ArrayList<>();
         subCategoryRepository.findAll().forEach(subCategory -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
                     subCategory.getName(),
                     productRepository.productCountWithSubCategory(subCategory.getId())
             );
-            productCategoryDtos.add(categoryDto);
+            subCategoryDtos.add(categoryDto);
         });
 
-        return productCategoryDtos;
+        ResponseProductAllCategoryDto allCategoryDto = ResponseProductAllCategoryDto.builder()
+                .main(mainCategoryDtos)
+                .sub(subCategoryDtos)
+                .build();
+
+        return allCategoryDto;
     }
 
     @Cacheable(value = "MallProduct", key = "#mallId + '_' + 'count'")
-    public List<ResponseProductCategoryDto> productCountWithCategoryOfMall(Long mallId) {
+    public ResponseProductAllCategoryDto productCountWithCategoryOfMall(Long mallId) {
         Mall mall = mallRepository.findById(mallId)
                 .orElseThrow(() -> new NoResultException("mall doesn't exist"));
-        List<ResponseProductCategoryDto> productCategoryDtos = new ArrayList<>();
 
+        List<ResponseProductCategoryDto> mainCategoryDtos = new ArrayList<>();
         categoryRepository.findAll().forEach(category -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
                     category.getName(),
                     productRepository.productCountWithCategoryOfMall(mall.getName(), category.getId())
             );
-            productCategoryDtos.add(categoryDto);
+            mainCategoryDtos.add(categoryDto);
         });
 
+        List<ResponseProductCategoryDto> subCategoryDtos = new ArrayList<>();
         subCategoryRepository.findAll().forEach(subCategory -> {
             ResponseProductCategoryDto categoryDto = CategoryMapper.INSTANCE.toResponseProductCategoryDto(
                     subCategory.getName(),
                     productRepository.productCountWithSubCategoryOfMall(mall.getName(), subCategory.getId())
             );
-            productCategoryDtos.add(categoryDto);
+            subCategoryDtos.add(categoryDto);
         });
 
-        return productCategoryDtos;
+        ResponseProductAllCategoryDto allCategoryDto = ResponseProductAllCategoryDto.builder()
+                .main(mainCategoryDtos)
+                .sub(subCategoryDtos)
+                .build();
+
+        return allCategoryDto;
     }
 
     public List<ResponseProductPreviewDto> recommendProduct(List<Long> productIds, boolean preview) {

--- a/src/main/java/fittering/mall/service/ProductService.java
+++ b/src/main/java/fittering/mall/service/ProductService.java
@@ -120,12 +120,10 @@ public class ProductService {
             subCategoryDtos.add(categoryDto);
         });
 
-        ResponseProductAllCategoryDto allCategoryDto = ResponseProductAllCategoryDto.builder()
+        return ResponseProductAllCategoryDto.builder()
                 .main(mainCategoryDtos)
                 .sub(subCategoryDtos)
                 .build();
-
-        return allCategoryDto;
     }
 
     @Cacheable(value = "MallProduct", key = "#mallId + '_' + 'count'")
@@ -151,12 +149,10 @@ public class ProductService {
             subCategoryDtos.add(categoryDto);
         });
 
-        ResponseProductAllCategoryDto allCategoryDto = ResponseProductAllCategoryDto.builder()
+        return ResponseProductAllCategoryDto.builder()
                 .main(mainCategoryDtos)
                 .sub(subCategoryDtos)
                 .build();
-
-        return allCategoryDto;
     }
 
     public List<ResponseProductPreviewDto> recommendProduct(List<Long> productIds, boolean preview) {


### PR DESCRIPTION
## API 수정 
### 카테고리별 상품 개수 조회 응답 변경
영향받는 API는 다음과 같습니다.
- 카테고리별 상품 개수 조회 : `/api/v1/categories/count`
- 쇼핑몰 내 카테고리별 상품 개수 조회 : `/api/v1/malls/{mallId}/categories/count`

카테고리별 상품 개수 조회 API는 각 카테고리마다 속해있는 상품 개수를 빠르게 확인할 수 있도록 값을 제공합니다.
기존에는 카테고리 대소분류를 구분할 수 없게 `{categoryName, count}`만 있었으나, **필드 `main`, `sub`를 생성해 구분했습니다.**
다음은 해당 API 반환 타입 `ResponseProductAllCategoryDto` 정보입니다.
```java
public class ResponseProductAllCategoryDto {
    List<ResponseProductCategoryDto> main;
    List<ResponseProductCategoryDto> sub;
}
```
- [fix: 대소분류에 맞게 상품 정보 구분](https://github.com/YeolJyeongKong/fittering-BE/commit/17fe32424d627e5b9833e532f15abbe42f15c902)
- [feat: 상품 개수 반환 API 응답 타입 재정의](https://github.com/YeolJyeongKong/fittering-BE/commit/8fa67e1991b7555e2fe78eb1600c89a0f8bf7fb4)

아래는 각 상품의 카테고리 정보와 개수를 나타내는 필드를 담은 `ResponseProductCategoryDto`입니다.
기존에는 카테고리명을 제공했으나, 다른 API에서 **카테고리명이 아닌 카테고리 ID를 요청값으로 넣을 수 있어** 불필요한 변환 과정을
거치지 않도록 카테고리 ID로 수정했습니다.
```java
public class ResponseProductCategoryDto {
    private Long categoryId; //categoryName -> categoryId
    private Long count;
}
```
- [fix: 카테고리 이름이 아닌 id로 접근하도록 수정](https://github.com/YeolJyeongKong/fittering-BE/commit/90eb6090d7e63954351f47b73a7190f78bcb4f58)