### PR TITLE
API 수정 : 쇼핑몰 리스트 조회 시 즐겨찾기 정보 포함

### DIFF
--- a/src/main/java/fittering/mall/controller/MallController.java
+++ b/src/main/java/fittering/mall/controller/MallController.java
@@ -76,9 +76,9 @@ public class MallController {
 
     @Operation(summary = "쇼핑몰 전체 리스트 조회")
     @ApiResponse(responseCode = "200", description = "SUCCESS", content = @Content(array = @ArraySchema(schema = @Schema(implementation = ResponseMallWithProductDto.class))))
-    @GetMapping("/malls/preview/list")
-    public ResponseEntity<?> mallList() {
-        List<ResponseMallWithProductDto> mallList = mallService.findAll();
+    @GetMapping("/auth/malls/preview/list")
+    public ResponseEntity<?> mallList(@AuthenticationPrincipal User user) {
+        List<ResponseMallWithProductDto> mallList = mallService.findAll(user.getId());
         return new ResponseEntity<>(mallList, HttpStatus.OK);
     }
 

--- a/src/main/java/fittering/mall/service/MallService.java
+++ b/src/main/java/fittering/mall/service/MallService.java
@@ -65,14 +65,15 @@ public class MallService {
         return responseMallNameAndIdList;
     }
 
-    public List<ResponseMallWithProductDto> findAll() {
+    public List<ResponseMallWithProductDto> findAll(Long userId) {
         List<ResponseMallWithProductDto> responseMallWithProductDtoList = new ArrayList<>();
         mallRepository.findAll().forEach(mall -> {
             List<Product> products = mall.getProducts();
             List<ResponseMallRankProductDto> productDtos = new ArrayList<>();
 
             getProductDtos(products, productDtos);
-            responseMallWithProductDtoList.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, 0, false));
+            Boolean isFavorite = favoriteRepository.isUserFavoriteMall(userId, mall.getId());
+            responseMallWithProductDtoList.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, 0, isFavorite));
         });
         return responseMallWithProductDtoList;
     }

--- a/src/test/java/fittering/mall/controller/MallControllerTest.java
+++ b/src/test/java/fittering/mall/controller/MallControllerTest.java
@@ -204,11 +204,11 @@ class MallControllerTest extends ControllerTestSupport {
                 .name("열졍콩몰2")
                 .build();
 
-        when(mallService.findAll()).thenReturn(List.of(mall1, mall2));
+        when(mallService.findAll(1L)).thenReturn(List.of(mall1, mall2));
 
         //when //then
         mockMvc.perform(
-                        get("/api/v1/malls/preview/list")
+                        get("/api/v1/auth/malls/preview/list")
                                 .with(csrf())
                 )
                 .andDo(print())

--- a/src/test/java/fittering/mall/service/MallServiceTest.java
+++ b/src/test/java/fittering/mall/service/MallServiceTest.java
@@ -219,7 +219,7 @@ class MallServiceTest extends IntegrationTestSupport {
         Mall savedMall3 = mallService.save(createMall());
 
         //when
-        List<ResponseMallWithProductDto> target = mallService.findAll();
+        List<ResponseMallWithProductDto> target = mallService.findAll(1L);
 
         //then
         assertThat(target).hasSize(3)


### PR DESCRIPTION
## API 수정
### 쇼핑몰 리스트 조회 시 즐겨찾기 정보 포함
기존에는 쇼핑몰 리스트 조회 시 즐겨찾기 정보인 `isFavorite`을 포함하는 응답을 내주고 있었으나, 이는 자주 조회한 쇼핑몰 정보를 얻을 때 사용하는 API 응답 타입과 같아 **쇼핑몰 리스트 조회 시에는 필요없는 필드라 판단해 false로 고정했었습니다.**

하지만 쇼핑몰 리스트 조회를 할 때에도 현재 사용자의 쇼핑몰 즐겨찾기 여부를 확인할 수 있어야 한다고 생각해 적절한 값을 반환할 수 있도록 로직을 수정했습니다. 또한 현재 사용자 정보에 따라 변경될 수 있는 정보를 반환하기에 API URI에 `/auth`를 추가했습니다.
- 기존 URI : `/api/v1/malls/preview/list` 
- API URI : `/api/v1/auth/malls/preview/list`

### 관련 로직
```java
public List<ResponseMallWithProductDto> findAll(Long userId) {
    List<ResponseMallWithProductDto> responseMallWithProductDtoList = new ArrayList<>();
    mallRepository.findAll().forEach(mall -> {
        ...
        //현재 사용자의 특정 쇼핑몰에 대한 즐겨찾기 정보 조회
        Boolean isFavorite = favoriteRepository.isUserFavoriteMall(userId, mall.getId());
        responseMallWithProductDtoList.add(MallMapper.INSTANCE.toResponseMallWithProductDto(mall, productDtos, 0, isFavorite));
    });
    return responseMallWithProductDtoList;
}
```